### PR TITLE
refactor: Django storage returns full URL

### DIFF
--- a/openassessment/fileupload/backends/django_storage.py
+++ b/openassessment/fileupload/backends/django_storage.py
@@ -33,7 +33,7 @@ class Backend(BaseBackend):
             storage_path = default_storage.url(path)
 
             # Return a fully-qualified URL
-            lms_url = getattr(settings, 'LMS_ROOT_URL')
+            lms_url = settings.LMS_ROOT_URL
             return urljoin(lms_url, storage_path)
         return None
 

--- a/openassessment/fileupload/backends/django_storage.py
+++ b/openassessment/fileupload/backends/django_storage.py
@@ -2,7 +2,9 @@
 
 
 import os
+from urllib.parse import urljoin
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.urls import reverse
@@ -28,7 +30,11 @@ class Backend(BaseBackend):
         """
         path = self._get_file_path(key)
         if default_storage.exists(path):
-            return default_storage.url(path)
+            storage_path = default_storage.url(path)
+
+            # Return a fully-qualified URL
+            lms_url = getattr(settings, 'LMS_ROOT_URL')
+            return urljoin(lms_url, storage_path)
         return None
 
     def upload_file(self, key, content):

--- a/openassessment/fileupload/backends/django_storage.py
+++ b/openassessment/fileupload/backends/django_storage.py
@@ -33,7 +33,7 @@ class Backend(BaseBackend):
             storage_path = default_storage.url(path)
 
             # Return a fully-qualified URL
-            lms_url = settings.LMS_ROOT_URL
+            lms_url = getattr(settings, 'LMS_ROOT_URL', '')  # pylint: disable=literal-used-as-attribute
             return urljoin(lms_url, storage_path)
         return None
 

--- a/openassessment/fileupload/tests/test_api.py
+++ b/openassessment/fileupload/tests/test_api.py
@@ -402,6 +402,7 @@ class TestSwiftBackend(TestCase):
     ORA2_FILEUPLOAD_BACKEND="django",
     DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage",
     FILE_UPLOAD_STORAGE_PREFIX="submissions",
+    LMS_ROOT_URL="http://foobar.example.com",
 )
 @ddt.ddt
 class TestFileUploadServiceWithDjangoStorageBackend(TestCase):
@@ -426,6 +427,7 @@ class TestFileUploadServiceWithDjangoStorageBackend(TestCase):
 
         self.key = "myfile.txt"
         self.content_type = "text/plain"
+        self.base_url = "http://foobar.example.com"
         self.tearDown()
 
     def tearDown(self):
@@ -466,7 +468,7 @@ class TestFileUploadServiceWithDjangoStorageBackend(TestCase):
         # Check updated download URL
         download_url = self.backend.get_download_url(self.key)
         encoded_key = urllib.parse.quote(self.key.encode('utf-8'))
-        self.assertEqual(f"submissions/{encoded_key}", download_url.lstrip('/'))
+        self.assertEqual(f"{self.base_url}/submissions/{encoded_key}", download_url.lstrip('/'))
 
     @ddt.data("noël.txt", "myfile.txt")
     def test_remove(self, key):
@@ -489,7 +491,7 @@ class TestFileUploadServiceWithDjangoStorageBackend(TestCase):
         # File exists now
         download_url = self.backend.get_download_url(self.key)
         encoded_key = urllib.parse.quote(self.key.encode('utf-8'))
-        self.assertEqual(f"submissions/{encoded_key}", download_url.lstrip('/'))
+        self.assertEqual(f"{self.base_url}/submissions/{encoded_key}", download_url.lstrip('/'))
 
         # Remove file returns True now, and removes the file
         self.assertTrue(self.backend.remove_file(self.key))

--- a/openassessment/fileupload/tests/test_file_management.py
+++ b/openassessment/fileupload/tests/test_file_management.py
@@ -1,5 +1,6 @@
 import json
 from unittest import mock
+from urllib.parse import urljoin
 
 from django.db import IntegrityError
 from django.test import TestCase
@@ -189,7 +190,8 @@ class FileUploadManagerTests(TestCase):
             actual_descriptors = other_users_file_manager.team_file_descriptors(team_id=self.team_id)
             self.assertEqual(2, len(actual_descriptors))
             for descriptor in actual_descriptors:
-                self.assertEqual(mock_default_storage.url.return_value, descriptor['download_url'])
+                expected_url = urljoin("http://foobar.example.com", mock_default_storage.url.return_value)
+                self.assertEqual(expected_url, descriptor['download_url'])
 
             actual_file_uploads = other_users_file_manager.get_team_uploads(team_id=self.team_id)
             self.assertEqual(2, len(actual_file_uploads))

--- a/openassessment/fileupload/tests/test_file_management.py
+++ b/openassessment/fileupload/tests/test_file_management.py
@@ -182,7 +182,9 @@ class FileUploadManagerTests(TestCase):
         other_users_block = MockBlock(number=2, team_id=self.team_id)
         other_users_block.student_id = MockBlock.STUDENT_ID + '317'
 
-        with mock.patch('openassessment.fileupload.backends.django_storage.Backend.get_download_url') as mock_get_download_url:
+        with mock.patch(
+            'openassessment.fileupload.backends.django_storage.Backend.get_download_url'
+        ) as mock_get_download_url:
             other_users_file_manager = FileUploadManager(other_users_block)
 
             actual_descriptors = other_users_file_manager.team_file_descriptors(team_id=self.team_id)

--- a/openassessment/fileupload/tests/test_file_management.py
+++ b/openassessment/fileupload/tests/test_file_management.py
@@ -81,7 +81,7 @@ class FileUploadManagerTests(TestCase):
         self.assertEqual(file_upload.description, expected_desc)
         self.assertEqual(file_upload.size, expected_size)
 
-    @override_settings(ORA2_FILEUPLOAD_BACKEND='django')
+    @override_settings(ORA2_FILEUPLOAD_BACKEND='django', LMS_ROOT_URL='http://foobar.example.com')
     def test_get_append_delete(self):
         files = self.manager.get_uploads()
         self.assertEqual(files, [])
@@ -119,7 +119,7 @@ class FileUploadManagerTests(TestCase):
             course_id=manager.block.course_id,
         ).all())
 
-    @override_settings(ORA2_FILEUPLOAD_BACKEND='django')
+    @override_settings(ORA2_FILEUPLOAD_BACKEND='django', LMS_ROOT_URL='http://foobar.example.com')
     def test_shared(self):
         files = self.team_manager.get_uploads()
         self.assertEqual(files, [])
@@ -170,6 +170,7 @@ class FileUploadManagerTests(TestCase):
     @override_settings(
         ORA2_FILEUPLOAD_BACKEND='django',
         MEDIA_ROOT='/tmp',
+        LMS_ROOT_URL='http://foobar.example.com',
     )
     def test_shared_file_descriptors_have_download_urls(self):
         self.team_manager.append_uploads(

--- a/openassessment/fileupload/tests/test_file_management.py
+++ b/openassessment/fileupload/tests/test_file_management.py
@@ -171,7 +171,6 @@ class FileUploadManagerTests(TestCase):
     @override_settings(
         ORA2_FILEUPLOAD_BACKEND='django',
         MEDIA_ROOT='/tmp',
-        LMS_ROOT_URL='http://foobar.example.com',
     )
     def test_shared_file_descriptors_have_download_urls(self):
         self.team_manager.append_uploads(
@@ -183,14 +182,13 @@ class FileUploadManagerTests(TestCase):
         other_users_block = MockBlock(number=2, team_id=self.team_id)
         other_users_block.student_id = MockBlock.STUDENT_ID + '317'
 
-        with mock.patch('openassessment.fileupload.backends.django_storage.default_storage') as mock_default_storage:
-            mock_default_storage.exists.return_value = True
+        with mock.patch('openassessment.fileupload.backends.django_storage.Backend.get_download_url') as mock_get_download_url:
             other_users_file_manager = FileUploadManager(other_users_block)
 
             actual_descriptors = other_users_file_manager.team_file_descriptors(team_id=self.team_id)
             self.assertEqual(2, len(actual_descriptors))
             for descriptor in actual_descriptors:
-                expected_url = urljoin("http://foobar.example.com", mock_default_storage.url.return_value)
+                expected_url = mock_get_download_url.return_value
                 self.assertEqual(expected_url, descriptor['download_url'])
 
             actual_file_uploads = other_users_file_manager.get_team_uploads(team_id=self.team_id)

--- a/urls.py
+++ b/urls.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.i18n import JavaScriptCatalog


### PR DESCRIPTION
**TL;DR -** to make file uploads work for ESG in devstack, update the `django_storage` file backend to return fully-qualified file download URLs instead of the relative-to-LMS URLs previously returned.

- [x] TODO - test updates

**Testing Instructions**

Do it work tho?

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
