### PR TITLE
refactor: make the list endpoint use a serializer

### DIFF
--- a/openassessment/staffgrader/serializers/__init__.py
+++ b/openassessment/staffgrader/serializers/__init__.py
@@ -1,5 +1,8 @@
 """ Serializers for the staff_grader app """
 
+from openassessment.staffgrader.serializers.submission_list import (
+    MissingContextException, SubmissionListScoreSerializer, SubmissionListSerializer
+)
 from openassessment.staffgrader.serializers.submission_lock import SubmissionLockSerializer
 from openassessment.staffgrader.serializers.assessments import (
     SubmissionDetailFileSerilaizer, AssessmentSerializer, AssessmentPartSerializer

--- a/openassessment/staffgrader/serializers/submission_list.py
+++ b/openassessment/staffgrader/serializers/submission_list.py
@@ -1,0 +1,100 @@
+"""
+Serializers for the Submission List endpoint
+"""
+from rest_framework import serializers
+from openassessment.assessment.models.staff import StaffWorkflow
+
+
+class MissingContextException(Exception):
+    pass
+
+
+# pylint: disable=abstract-method
+class SubmissionListScoreSerializer(serializers.Serializer):
+    pointsEarned = serializers.IntegerField(source='points_earned')
+    pointsPossible = serializers.IntegerField(source='points_possible')
+
+
+class SubmissionListSerializer(serializers.ModelSerializer):
+    """
+    Serialized info about an item returned from the submission list endpoint
+    """
+    class Meta:
+        model = StaffWorkflow
+        fields = [
+            'submissionUuid',
+            'dateSubmitted',
+            'dateGraded',
+            'gradingStatus',
+            'lockStatus',
+            'gradedBy',
+            'username',
+            'score'
+        ]
+        read_only_fields = fields
+
+    requires_context = True
+
+    CONTEXT_SUB_TO_ANON_ID = 'submission_uuid_to_student_id'
+    CONTEXT_ANON_ID_TO_USERNAME = 'anonymous_id_to_username'
+    CONTEXT_SUB_TO_ASSESSMENT = 'submission_uuid_to_assessment'
+
+    def _verify_required_context(self, context):
+        context_keys = set(context.keys())
+        required_context = set([
+            self.CONTEXT_ANON_ID_TO_USERNAME,
+            self.CONTEXT_SUB_TO_ANON_ID,
+            self.CONTEXT_SUB_TO_ASSESSMENT
+        ])
+        missing_context = required_context - context_keys
+        if missing_context:
+            raise ValueError(f"Missing required context {' ,'.join(missing_context)}")
+
+    def __init__(self, *args, **kwargs):
+        self._verify_required_context(kwargs.get('context', {}))
+        super().__init__(*args, **kwargs)
+
+    submissionUuid = serializers.CharField(source='submission_uuid')
+    dateSubmitted = serializers.CharField(source='created_at')
+    dateGraded = serializers.CharField(source='grading_completed_at')
+    dateGraded = serializers.SerializerMethodField()
+    gradingStatus = serializers.CharField(source='grading_status')
+    lockStatus = serializers.CharField(source='lock_status')
+    gradedBy = serializers.SerializerMethodField()
+    username = serializers.SerializerMethodField()
+    score = serializers.SerializerMethodField()
+
+    def _get_username_from_context(self, anonymous_user_id):
+        try:
+            return self.context[self.CONTEXT_ANON_ID_TO_USERNAME][anonymous_user_id]
+        except KeyError as e:
+            raise MissingContextException(f"Username not found for anonymous user id {anonymous_user_id}") from e
+
+    def _get_anonymous_id_from_context(self, submission_uuid):
+        try:
+            return self.context[self.CONTEXT_SUB_TO_ANON_ID][submission_uuid]
+        except KeyError as e:
+            raise MissingContextException(
+                f"No submitter anonymous user id found for submission uuid {submission_uuid}"
+            ) from e
+
+    def get_dateGraded(self, workflow):
+        return str(workflow.grading_completed_at)
+
+    def get_gradedBy(self, workflow):
+        if workflow.scorer_id:
+            return self._get_username_from_context(workflow.scorer_id)
+        else:
+            return None
+
+    def get_username(self, workflow):
+        return self._get_username_from_context(
+            self._get_anonymous_id_from_context(workflow.identifying_uuid)
+        )
+
+    def get_score(self, workflow):
+        assessment = self.context[self.CONTEXT_SUB_TO_ASSESSMENT].get(workflow.identifying_uuid)
+        if assessment:
+            return SubmissionListScoreSerializer(assessment).data
+        else:
+            return {}

--- a/openassessment/staffgrader/tests/test_serializers.py
+++ b/openassessment/staffgrader/tests/test_serializers.py
@@ -1,10 +1,19 @@
 """
 Tests for serializers used in staff grading
 """
+from contextlib import contextmanager, ExitStack
 from datetime import datetime, timedelta, timezone
+from typing import OrderedDict
 from uuid import uuid4
-from freezegun import freeze_time
 
+import ddt
+from django.test.testcases import TestCase
+from freezegun import freeze_time
+from mock import Mock, patch
+
+from openassessment.staffgrader.serializers.submission_list import (
+    SubmissionListSerializer, SubmissionListScoreSerializer
+)
 from openassessment.staffgrader.models.submission_lock import SubmissionGradingLock
 from openassessment.staffgrader.serializers.submission_lock import SubmissionLockSerializer
 from openassessment.test_utils import CacheResetTest
@@ -74,3 +83,221 @@ class TestSubmissionLockSerializer(CacheResetTest):
         }
 
         assert SubmissionLockSerializer(self.test_submission_lock, context=context).data == expected_output
+
+
+class BaseSerializerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.maxDiff = None
+
+
+@ddt.ddt
+class TestSubmissionListScoreSerializer(BaseSerializerTest):
+
+    @ddt.unpack
+    @ddt.data((1, 10), (99, 100), (0, 0))
+    def test_serializer(self, earned, possible):
+        mock_assessment = Mock(points_earned=earned, points_possible=possible)
+        assert SubmissionListScoreSerializer(mock_assessment).data == {
+            'pointsEarned': mock_assessment.points_earned,
+            'pointsPossible': mock_assessment.points_possible
+        }
+
+
+@ddt.ddt
+class TestSubmissionListSerializer(BaseSerializerTest):
+
+    @contextmanager
+    def mock_get_gradedBy(self):
+        with patch.object(SubmissionListSerializer, 'get_gradedBy', return_value='get_gradedBy'):
+            yield
+
+    @contextmanager
+    def mock_get_username(self):
+        with patch.object(SubmissionListSerializer, 'get_username', return_value='get_username'):
+            yield
+
+    @contextmanager
+    def mock_get_score(self):
+        with patch.object(SubmissionListSerializer, 'get_score', return_value='get_score'):
+            yield
+
+    @contextmanager
+    def mock_verify_required_context(self):
+        with patch.object(SubmissionListSerializer, '_verify_required_context'):
+            yield
+
+    @contextmanager
+    def mock_serializer_methods(self, gradedBy=False, username=False, score=False, verify=False):
+        with ExitStack() as stack:
+            if gradedBy:
+                stack.enter_context(self.mock_get_gradedBy())
+            if username:
+                stack.enter_context(self.mock_get_username())
+            if score:
+                stack.enter_context(self.mock_get_score())
+            if verify:
+                stack.enter_context(self.mock_verify_required_context())
+            yield
+
+    def test_serializer(self):
+        mock_workflow = Mock()
+        with self.mock_serializer_methods(gradedBy=True, username=True, score=True, verify=True):
+            result = SubmissionListSerializer(mock_workflow).data
+        self.assertDictEqual(
+            result,
+            {
+                'submissionUuid': str(mock_workflow.submission_uuid),
+                'dateSubmitted': str(mock_workflow.created_at),
+                'dateGraded': str(mock_workflow.grading_completed_at),
+                'gradingStatus': str(mock_workflow.grading_status),
+                'lockStatus': str(mock_workflow.lock_status),
+                'gradedBy': 'get_gradedBy',
+                'username': 'get_username',
+                'score': 'get_score',
+            }
+        )
+
+    @ddt.data(True, False)
+    def test_get_gradedBy(self, has_scorer_id):
+        mock_workflow = Mock()
+        scorer_id, scorer_username = 'test_scorer_id', 'test_scorer_username'
+        if has_scorer_id:
+            mock_workflow.scorer_id = scorer_id
+        else:
+            mock_workflow.scorer_id = None
+
+        with self.mock_serializer_methods(username=True, score=True, verify=True):
+            result = SubmissionListSerializer(
+                mock_workflow,
+                context={
+                    'anonymous_id_to_username': {scorer_id: scorer_username}
+                }
+            ).data
+        if has_scorer_id:
+            self.assertEqual(result['gradedBy'], scorer_username)
+        else:
+            self.assertIsNone(result['gradedBy'])
+
+    @ddt.data(True, False)
+    def test_get_score(self, has_assessment):
+        mock_workflow = Mock()
+        # mock_workflow.identifying_uuid = str(mock_workflow.identifying_uuid)
+        mock_assessment = Mock()
+
+        mock_submission_uuid_to_assessment = {}
+        if has_assessment:
+            mock_submission_uuid_to_assessment[mock_workflow.identifying_uuid] = mock_assessment
+
+        with self.mock_serializer_methods(gradedBy=True, username=True, verify=True):
+            with patch(
+                'openassessment.staffgrader.serializers.submission_list.SubmissionListScoreSerializer'
+            ) as mock_score_serializer:
+                result = SubmissionListSerializer(
+                    mock_workflow,
+                    context={
+                        'submission_uuid_to_assessment': mock_submission_uuid_to_assessment
+                    }
+                ).data
+
+        if has_assessment:
+            mock_score_serializer.assert_called_once_with(mock_assessment)
+            self.assertEqual(result['score'], mock_score_serializer.return_value.data)
+        else:
+            self.assertEqual(result['score'], {})
+
+    def test_get_username(self):
+        mock_workflow = Mock()
+        # mock_workflow.identifying_uuid = str(mock_workflow.identifying_uuid)
+        student_id, username = 'test_student_id', 'test_username'
+
+        with self.mock_serializer_methods(gradedBy=True, score=True, verify=True):
+            result = SubmissionListSerializer(
+                mock_workflow,
+                context={
+                    'submission_uuid_to_student_id': {mock_workflow.identifying_uuid: student_id},
+                    'anonymous_id_to_username': {student_id: username}
+                }
+            ).data
+
+        self.assertEqual(result['username'], username)
+
+    def test_integration(self):
+        # Make three workflows. The first two have scorer_ids and the third does not
+        workflows = [
+            Mock(scorer_id='staff_student_id_1'),
+            Mock(scorer_id='staff_student_id_2'),
+            Mock(scorer_id=None)
+        ]
+
+        # Dict from workflow uuids to student_id_{0,1,2}
+        submission_uuid_to_student_id = {
+            workflow.identifying_uuid: f'student_id_{i}'
+            for i, workflow in enumerate(workflows)
+        }
+
+        # Simple mapping of student_id_n to username_n
+        anonymous_id_to_username = {
+            f'student_id_{i}': f'username_{i}'
+            for i in range(3)
+        }
+        # also include usernames for the scorers of the first two workflows
+        anonymous_id_to_username[workflows[0].scorer_id] = 'staff_username_1'
+        anonymous_id_to_username[workflows[1].scorer_id] = 'staff_username_2'
+
+        # Add assessments for the "scored" workflows
+        submission_uuid_to_assessment = {
+            workflows[0].identifying_uuid: Mock(points_possible=20, points_earned=10),
+            workflows[1].identifying_uuid: Mock(points_possible=20, points_earned=7),
+        }
+
+        data = SubmissionListSerializer(
+            workflows,
+            context={
+                'submission_uuid_to_student_id': submission_uuid_to_student_id,
+                'anonymous_id_to_username': anonymous_id_to_username,
+                'submission_uuid_to_assessment': submission_uuid_to_assessment,
+            },
+            many=True
+        ).data
+
+        expected_data = [
+            OrderedDict({
+                'submissionUuid': str(workflows[0].submission_uuid),
+                'dateSubmitted': str(workflows[0].created_at),
+                'dateGraded': str(workflows[0].grading_completed_at),
+                'gradingStatus': str(workflows[0].grading_status),
+                'lockStatus': str(workflows[0].lock_status),
+                'gradedBy': 'staff_username_1',
+                'username': 'username_0',
+                'score': {
+                    'pointsEarned': 10,
+                    'pointsPossible': 20,
+                },
+            }),
+            OrderedDict({
+                'submissionUuid': str(workflows[1].submission_uuid),
+                'dateSubmitted': str(workflows[1].created_at),
+                'dateGraded': str(workflows[1].grading_completed_at),
+                'gradingStatus': str(workflows[1].grading_status),
+                'lockStatus': str(workflows[1].lock_status),
+                'gradedBy': 'staff_username_2',
+                'username': 'username_1',
+                'score': {
+                    'pointsEarned': 7,
+                    'pointsPossible': 20,
+                },
+            }),
+            OrderedDict({
+                'submissionUuid': str(workflows[2].submission_uuid),
+                'dateSubmitted': str(workflows[2].created_at),
+                'dateGraded': str(workflows[2].grading_completed_at),
+                'gradingStatus': str(workflows[2].grading_status),
+                'lockStatus': str(workflows[2].lock_status),
+                'gradedBy': None,
+                'username': 'username_2',
+                'score': {},
+            })
+        ]
+
+        self.assertEqual(data, expected_data)


### PR DESCRIPTION
**TL;DR -** make the list endpoint use a serializer rather than manual serialization

JIRA: [AU-488](https://openedx.atlassian.net/browse/AU-488)

**What changed?**

- Pulled the lookups out of `staff_workflows_to_api_format` into new function,` _get_list_workflows_serializer_context`
- Then, rather than manually serializing, pass workflows to a serializer along with the context looked up in `_get_list_workflows_serializer_context`

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
