### PR TITLE
chore: bump pip-tools to 6.5.0 to resolve pip bug

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.0
     # via -r requirements/pip-tools.in
 tomli==2.0.0
     # via pep517


### PR DESCRIPTION
make upgrade failed because of https://github.com/jazzband/pip-tools/issues/1558

6.5.0 resolves the issue so after merge requirements upgrade should work again
