### PR TITLE
chore: rename github group to match org. structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, they will
 # be requested for review when someone opens a pull request.
-*       @edx/masters-devs-gta
+*       @openedx/content-aurora

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,4 +25,4 @@ Collectively, these should be completed by reviewers of this PR:
 - [ ] I've done a visual code review
 - [ ] I've tested the new functionality
 
-FYI: @edx/masters-devs-gta
+FYI: @openedx/content-aurora


### PR DESCRIPTION
**TL;DR -** [ A short summary of what this PR does and why ]

JIRA: [JIRA-XXXX](https://openedx.atlassian.net/browse/JIRA-XXXX)

**What changed?**

- [ More in depth breakdown of changes ]
- [ Peripheral things that got changed ]
- [ etc... ]

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @edx/masters-devs-gta
