### PR TITLE
feat: add get team staff workflow

### DIFF
--- a/openassessment/assessment/models/staff.py
+++ b/openassessment/assessment/models/staff.py
@@ -223,3 +223,11 @@ class TeamStaffWorkflow(StaffWorkflow):
         (submission_uuid for StaffWorkflow, team_submission_uuid for TeamStaffWorkflow)
         """
         return self.team_submission_uuid
+
+    @classmethod
+    def get_team_staff_workflow(cls, course_id, item_id, team_submission_uuid):
+        return cls.objects.get(
+            course_id=course_id,
+            item_id=item_id,
+            team_submission_uuid=team_submission_uuid
+        )

--- a/openassessment/staffgrader/tests/test_get_assessment_info.py
+++ b/openassessment/staffgrader/tests/test_get_assessment_info.py
@@ -42,6 +42,15 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
         ) as mock_get:
             yield mock_get
 
+    @contextmanager
+    def _mock_get_team_staff_workflow(self, **kwargs):
+        """ Context manager for mocking the lookup of Team Staff Workflows """
+        with patch(
+            'openassessment.staffgrader.staff_grader_mixin.TeamStaffWorkflow.get_team_staff_workflow',
+            **kwargs
+        ) as mock_get:
+            yield mock_get
+
     def _mock_get_download_urls_from_submission(self, xblock, **kwargs):
         """ Helper method to mock getting uploaded file info from a submission"""
         xblock.get_download_urls_from_submission = Mock(**kwargs)


### PR DESCRIPTION
**TL;DR -** to support teams in ESG, add the ability to get a staff workflow for a team.

**Note:** based on the way the tickets are broken up, nothing exercises this yet so there are no unit tests yet. I did add the mock context manager though for future test use.

JIRA: [AU-495](https://openedx.atlassian.net/browse/AU-495)

**What changed?**

- add `TeamStaffWorkflow.get_team_staff_workflow`
- add mock context manager for the above.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

n/a

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
