### PR TITLE
feat: ESG team support

### DIFF
--- a/openassessment/staffgrader/serializers/__init__.py
+++ b/openassessment/staffgrader/serializers/__init__.py
@@ -1,7 +1,7 @@
 """ Serializers for the staff_grader app """
 
 from openassessment.staffgrader.serializers.submission_list import (
-    MissingContextException, SubmissionListScoreSerializer, SubmissionListSerializer
+    MissingContextException, SubmissionListScoreSerializer, SubmissionListSerializer, TeamSubmissionListSerializer
 )
 from openassessment.staffgrader.serializers.submission_lock import SubmissionLockSerializer
 from openassessment.staffgrader.serializers.assessments import (

--- a/openassessment/staffgrader/serializers/submission_list.py
+++ b/openassessment/staffgrader/serializers/submission_list.py
@@ -115,22 +115,6 @@ class TeamSubmissionListSerializer(SubmissionListSerializer):
     """
     Serialized info about an team item returned from the submission list endpoint
     """
-    class Meta:
-        model = StaffWorkflow
-        fields = [
-            'submissionUuid',
-            'dateSubmitted',
-            'dateGraded',
-            'gradingStatus',
-            'lockStatus',
-            'gradedBy',
-            'username',
-            'teamName',
-            'score'
-        ]
-        read_only_fields = fields
-
-    requires_context = True
 
     # Required context
     CONTEXT_ANON_ID_TO_USERNAME = 'anonymous_id_to_username'
@@ -153,21 +137,6 @@ class TeamSubmissionListSerializer(SubmissionListSerializer):
         missing_context = required_context - context_keys
         if missing_context:
             raise ValueError(f"Missing required context {' ,'.join(missing_context)}")
-
-    def __init__(self, *args, **kwargs):
-        self._verify_required_context(kwargs.get('context', {}))
-        super().__init__(*args, **kwargs)
-
-    submissionUuid = serializers.CharField(source='submission_uuid')
-    dateSubmitted = serializers.CharField(source='created_at')
-    dateGraded = serializers.CharField(source='grading_completed_at')
-    dateGraded = serializers.SerializerMethodField()
-    gradingStatus = serializers.CharField(source='grading_status')
-    lockStatus = serializers.CharField(source='lock_status')
-    gradedBy = serializers.SerializerMethodField()
-    username = serializers.SerializerMethodField()
-    teamName = serializers.SerializerMethodField()
-    score = serializers.SerializerMethodField()
 
     def _get_team_name_from_context(self, team_id):
         try:

--- a/openassessment/staffgrader/serializers/submission_list.py
+++ b/openassessment/staffgrader/serializers/submission_list.py
@@ -116,6 +116,8 @@ class TeamSubmissionListSerializer(SubmissionListSerializer):
     Serialized info about an team item returned from the submission list endpoint
     """
 
+    submissionUuid = serializers.CharField(source='team_submission_uuid')
+
     # Required context
     CONTEXT_ANON_ID_TO_USERNAME = 'anonymous_id_to_username'
     CONTEXT_SUB_TO_ASSESSMENT = 'submission_uuid_to_assessment'

--- a/openassessment/staffgrader/serializers/submission_list.py
+++ b/openassessment/staffgrader/serializers/submission_list.py
@@ -99,7 +99,7 @@ class SubmissionListSerializer(serializers.ModelSerializer):
             self._get_anonymous_id_from_context(workflow.identifying_uuid)
         )
 
-    def get_teamName(self, workflow):
+    def get_teamName(self, workflow):  # pylint: disable=unused-argument
         # For individual submissions, this is intentionally empty
         return None
 
@@ -154,7 +154,7 @@ class TeamSubmissionListSerializer(SubmissionListSerializer):
                 f"No submitter anonymous user id found for team submission uuid {team_submission_uuid}"
             ) from e
 
-    def get_username(self, workflow):
+    def get_username(self, workflow):  # pylint: disable=unused-argument
         # For team submissions, this is intentionally empty
         return None
 

--- a/openassessment/staffgrader/serializers/submission_list.py
+++ b/openassessment/staffgrader/serializers/submission_list.py
@@ -45,7 +45,7 @@ class SubmissionListSerializer(serializers.ModelSerializer):
         """Verify that required individual or team context is present for serialization"""
         context_keys = set(context.keys())
 
-        # Required context for all submission types
+        # Required context for individual submissions
         required_context = set([
             self.CONTEXT_ANON_ID_TO_USERNAME,
             self.CONTEXT_SUB_TO_ASSESSMENT,
@@ -118,23 +118,25 @@ class TeamSubmissionListSerializer(SubmissionListSerializer):
 
     submissionUuid = serializers.CharField(source='team_submission_uuid')
 
-    # Required context
+    # Context keys
     CONTEXT_ANON_ID_TO_USERNAME = 'anonymous_id_to_username'
     CONTEXT_SUB_TO_ASSESSMENT = 'submission_uuid_to_assessment'
     CONTEXT_SUB_TO_TEAM_ID = 'team_submission_uuid_to_team_id'
     CONTEXT_TEAM_ID_TO_TEAM_NAME = 'team_id_to_team_name'
+
+    REQUIRED_CONTEXT_KEYS = [
+        CONTEXT_ANON_ID_TO_USERNAME,
+        CONTEXT_SUB_TO_ASSESSMENT,
+        CONTEXT_SUB_TO_TEAM_ID,
+        CONTEXT_TEAM_ID_TO_TEAM_NAME,
+    ]
 
     def _verify_required_context(self, context):
         """Verify that required team context is present for serialization"""
         context_keys = set(context.keys())
 
         # Required context for serialization
-        required_context = set([
-            self.CONTEXT_ANON_ID_TO_USERNAME,
-            self.CONTEXT_SUB_TO_ASSESSMENT,
-            self.CONTEXT_SUB_TO_TEAM_ID,
-            self.CONTEXT_TEAM_ID_TO_TEAM_NAME,
-        ])
+        required_context = set(self.REQUIRED_CONTEXT_KEYS)
 
         missing_context = required_context - context_keys
         if missing_context:

--- a/openassessment/staffgrader/serializers/submission_list.py
+++ b/openassessment/staffgrader/serializers/submission_list.py
@@ -29,23 +29,52 @@ class SubmissionListSerializer(serializers.ModelSerializer):
             'lockStatus',
             'gradedBy',
             'username',
+            'teamName',
             'score'
         ]
         read_only_fields = fields
 
     requires_context = True
 
-    CONTEXT_SUB_TO_ANON_ID = 'submission_uuid_to_student_id'
+    # Always required context
+    CONTEXT_IS_TEAM_ASSIGNMENT = 'is_team_assignment'
     CONTEXT_ANON_ID_TO_USERNAME = 'anonymous_id_to_username'
     CONTEXT_SUB_TO_ASSESSMENT = 'submission_uuid_to_assessment'
 
+    # Individual submission context
+    CONTEXT_SUB_TO_ANON_ID = 'submission_uuid_to_student_id'
+
+    # Team submission context
+    CONTEXT_SUB_TO_TEAM_ID = 'team_submission_uuid_to_team_id'
+    CONTEXT_TEAM_ID_TO_TEAM_NAME = 'team_id_to_team_name'
+
+    def _is_team_submission(self):
+        """Utility function for if this is team vs individual submisison list"""
+        return self.context.get(self.CONTEXT_IS_TEAM_ASSIGNMENT, False)
+
     def _verify_required_context(self, context):
+        """Verify that required individual or team context is present for serialization"""
         context_keys = set(context.keys())
+
+        # Required context for all submission types
         required_context = set([
+            self.CONTEXT_IS_TEAM_ASSIGNMENT,
             self.CONTEXT_ANON_ID_TO_USERNAME,
-            self.CONTEXT_SUB_TO_ANON_ID,
             self.CONTEXT_SUB_TO_ASSESSMENT
         ])
+
+        # Required team context
+        if context.get(self.CONTEXT_IS_TEAM_ASSIGNMENT, False):
+            required_context.update([
+                self.CONTEXT_SUB_TO_TEAM_ID,
+                self.CONTEXT_TEAM_ID_TO_TEAM_NAME,
+            ])
+        # Required individual context
+        else:
+            required_context.update([
+                self.CONTEXT_SUB_TO_ANON_ID
+            ])
+
         missing_context = required_context - context_keys
         if missing_context:
             raise ValueError(f"Missing required context {' ,'.join(missing_context)}")
@@ -62,6 +91,7 @@ class SubmissionListSerializer(serializers.ModelSerializer):
     lockStatus = serializers.CharField(source='lock_status')
     gradedBy = serializers.SerializerMethodField()
     username = serializers.SerializerMethodField()
+    teamName = serializers.SerializerMethodField()
     score = serializers.SerializerMethodField()
 
     def _get_username_from_context(self, anonymous_user_id):
@@ -69,6 +99,20 @@ class SubmissionListSerializer(serializers.ModelSerializer):
             return self.context[self.CONTEXT_ANON_ID_TO_USERNAME][anonymous_user_id]
         except KeyError as e:
             raise MissingContextException(f"Username not found for anonymous user id {anonymous_user_id}") from e
+
+    def _get_team_name_from_context(self, team_id):
+        try:
+            return self.context[self.CONTEXT_TEAM_ID_TO_TEAM_NAME][team_id]
+        except KeyError as e:
+            raise MissingContextException(f"Team name not found for team id {team_id}") from e
+
+    def _get_team_id_from_context(self, team_submission_uuid):
+        try:
+            return self.context[self.CONTEXT_SUB_TO_TEAM_ID][team_submission_uuid]
+        except KeyError as e:
+            raise MissingContextException(
+                f"No submitter anonymous user id found for team submission uuid {team_submission_uuid}"
+            ) from e
 
     def _get_anonymous_id_from_context(self, submission_uuid):
         try:
@@ -88,8 +132,17 @@ class SubmissionListSerializer(serializers.ModelSerializer):
             return None
 
     def get_username(self, workflow):
+        if self._is_team_submission():
+            return None
         return self._get_username_from_context(
             self._get_anonymous_id_from_context(workflow.identifying_uuid)
+        )
+
+    def get_teamName(self, workflow):
+        if not self._is_team_submission():
+            return None
+        return self._get_team_name_from_context(
+            self._get_team_id_from_context(workflow.identifying_uuid)
         )
 
     def get_score(self, workflow):

--- a/openassessment/staffgrader/serializers/submission_list.py
+++ b/openassessment/staffgrader/serializers/submission_list.py
@@ -36,21 +36,10 @@ class SubmissionListSerializer(serializers.ModelSerializer):
 
     requires_context = True
 
-    # Always required context
-    CONTEXT_IS_TEAM_ASSIGNMENT = 'is_team_assignment'
+    # Required context
     CONTEXT_ANON_ID_TO_USERNAME = 'anonymous_id_to_username'
     CONTEXT_SUB_TO_ASSESSMENT = 'submission_uuid_to_assessment'
-
-    # Individual submission context
     CONTEXT_SUB_TO_ANON_ID = 'submission_uuid_to_student_id'
-
-    # Team submission context
-    CONTEXT_SUB_TO_TEAM_ID = 'team_submission_uuid_to_team_id'
-    CONTEXT_TEAM_ID_TO_TEAM_NAME = 'team_id_to_team_name'
-
-    def _is_team_submission(self):
-        """Utility function for if this is team vs individual submisison list"""
-        return self.context.get(self.CONTEXT_IS_TEAM_ASSIGNMENT, False)
 
     def _verify_required_context(self, context):
         """Verify that required individual or team context is present for serialization"""
@@ -58,22 +47,10 @@ class SubmissionListSerializer(serializers.ModelSerializer):
 
         # Required context for all submission types
         required_context = set([
-            self.CONTEXT_IS_TEAM_ASSIGNMENT,
             self.CONTEXT_ANON_ID_TO_USERNAME,
-            self.CONTEXT_SUB_TO_ASSESSMENT
+            self.CONTEXT_SUB_TO_ASSESSMENT,
+            self.CONTEXT_SUB_TO_ANON_ID
         ])
-
-        # Required team context
-        if context.get(self.CONTEXT_IS_TEAM_ASSIGNMENT, False):
-            required_context.update([
-                self.CONTEXT_SUB_TO_TEAM_ID,
-                self.CONTEXT_TEAM_ID_TO_TEAM_NAME,
-            ])
-        # Required individual context
-        else:
-            required_context.update([
-                self.CONTEXT_SUB_TO_ANON_ID
-            ])
 
         missing_context = required_context - context_keys
         if missing_context:
@@ -100,20 +77,6 @@ class SubmissionListSerializer(serializers.ModelSerializer):
         except KeyError as e:
             raise MissingContextException(f"Username not found for anonymous user id {anonymous_user_id}") from e
 
-    def _get_team_name_from_context(self, team_id):
-        try:
-            return self.context[self.CONTEXT_TEAM_ID_TO_TEAM_NAME][team_id]
-        except KeyError as e:
-            raise MissingContextException(f"Team name not found for team id {team_id}") from e
-
-    def _get_team_id_from_context(self, team_submission_uuid):
-        try:
-            return self.context[self.CONTEXT_SUB_TO_TEAM_ID][team_submission_uuid]
-        except KeyError as e:
-            raise MissingContextException(
-                f"No submitter anonymous user id found for team submission uuid {team_submission_uuid}"
-            ) from e
-
     def _get_anonymous_id_from_context(self, submission_uuid):
         try:
             return self.context[self.CONTEXT_SUB_TO_ANON_ID][submission_uuid]
@@ -132,18 +95,13 @@ class SubmissionListSerializer(serializers.ModelSerializer):
             return None
 
     def get_username(self, workflow):
-        if self._is_team_submission():
-            return None
         return self._get_username_from_context(
             self._get_anonymous_id_from_context(workflow.identifying_uuid)
         )
 
     def get_teamName(self, workflow):
-        if not self._is_team_submission():
-            return None
-        return self._get_team_name_from_context(
-            self._get_team_id_from_context(workflow.identifying_uuid)
-        )
+        # For individual submissions, this is intentionally empty
+        return None
 
     def get_score(self, workflow):
         assessment = self.context[self.CONTEXT_SUB_TO_ASSESSMENT].get(workflow.identifying_uuid)
@@ -151,3 +109,85 @@ class SubmissionListSerializer(serializers.ModelSerializer):
             return SubmissionListScoreSerializer(assessment).data
         else:
             return {}
+
+
+class TeamSubmissionListSerializer(SubmissionListSerializer):
+    """
+    Serialized info about an team item returned from the submission list endpoint
+    """
+    class Meta:
+        model = StaffWorkflow
+        fields = [
+            'submissionUuid',
+            'dateSubmitted',
+            'dateGraded',
+            'gradingStatus',
+            'lockStatus',
+            'gradedBy',
+            'username',
+            'teamName',
+            'score'
+        ]
+        read_only_fields = fields
+
+    requires_context = True
+
+    # Required context
+    CONTEXT_ANON_ID_TO_USERNAME = 'anonymous_id_to_username'
+    CONTEXT_SUB_TO_ASSESSMENT = 'submission_uuid_to_assessment'
+    CONTEXT_SUB_TO_TEAM_ID = 'team_submission_uuid_to_team_id'
+    CONTEXT_TEAM_ID_TO_TEAM_NAME = 'team_id_to_team_name'
+
+    def _verify_required_context(self, context):
+        """Verify that required team context is present for serialization"""
+        context_keys = set(context.keys())
+
+        # Required context for serialization
+        required_context = set([
+            self.CONTEXT_ANON_ID_TO_USERNAME,
+            self.CONTEXT_SUB_TO_ASSESSMENT,
+            self.CONTEXT_SUB_TO_TEAM_ID,
+            self.CONTEXT_TEAM_ID_TO_TEAM_NAME,
+        ])
+
+        missing_context = required_context - context_keys
+        if missing_context:
+            raise ValueError(f"Missing required context {' ,'.join(missing_context)}")
+
+    def __init__(self, *args, **kwargs):
+        self._verify_required_context(kwargs.get('context', {}))
+        super().__init__(*args, **kwargs)
+
+    submissionUuid = serializers.CharField(source='submission_uuid')
+    dateSubmitted = serializers.CharField(source='created_at')
+    dateGraded = serializers.CharField(source='grading_completed_at')
+    dateGraded = serializers.SerializerMethodField()
+    gradingStatus = serializers.CharField(source='grading_status')
+    lockStatus = serializers.CharField(source='lock_status')
+    gradedBy = serializers.SerializerMethodField()
+    username = serializers.SerializerMethodField()
+    teamName = serializers.SerializerMethodField()
+    score = serializers.SerializerMethodField()
+
+    def _get_team_name_from_context(self, team_id):
+        try:
+            return self.context[self.CONTEXT_TEAM_ID_TO_TEAM_NAME][team_id]
+        except KeyError as e:
+            raise MissingContextException(f"Team name not found for team id {team_id}") from e
+
+    def _get_team_id_from_context(self, team_submission_uuid):
+        try:
+            return self.context[self.CONTEXT_SUB_TO_TEAM_ID][team_submission_uuid]
+        except KeyError as e:
+            raise MissingContextException(
+                f"No submitter anonymous user id found for team submission uuid {team_submission_uuid}"
+            ) from e
+
+    def get_username(self, workflow):
+        # For team submissions, this is intentionally empty
+        return None
+
+    def get_teamName(self, workflow):
+        return self._get_team_name_from_context(
+            self._get_team_id_from_context(workflow.identifying_uuid)
+        )

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -152,7 +152,9 @@ class StaffGraderMixin:
 
         # Lookup additional info like usernames and assessments and determine serializer type
         serializer = TeamSubmissionListSerializer if is_team_assignment else SubmissionListSerializer
-        serializer_context = self._get_list_workflows_serializer_context(staff_workflows, is_team_assignment=is_team_assignment)
+        serializer_context = self._get_list_workflows_serializer_context(
+            staff_workflows, is_team_assignment=is_team_assignment
+        )
 
         # Serialize workflows with the context, and return the dict of submissions
         result = {}

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -357,8 +357,12 @@ class StaffGraderMixin:
         student_item_dict = self.get_student_item_dict()
         course_id = student_item_dict['course_id']
         item_id = student_item_dict['item_id']
+
         try:
-            workflow = StaffWorkflow.get_staff_workflow(course_id, item_id, submission_uuid)
+            if self.is_team_assignment():
+                workflow = TeamStaffWorkflow.get_team_staff_workflow(course_id, item_id, submission_uuid)
+            else:
+                workflow = StaffWorkflow.get_staff_workflow(course_id, item_id, submission_uuid)
         except StaffWorkflow.DoesNotExist as ex:
             msg = f"No gradeable submission found with uuid={submission_uuid} in course={course_id} item={item_id}"
             raise JsonHandlerError(404, msg) from ex

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -6,16 +6,15 @@ import logging
 
 from django.db.models import Case, OuterRef, Prefetch, Subquery, Value, When
 from django.db.models.fields import CharField
-from openassessment.staffgrader.serializers.submission_list import TeamSubmissionListSerializer
+from submissions.api import get_student_ids_by_submission_uuid, get_submission
+from submissions.errors import SubmissionInternalError, SubmissionNotFoundError, SubmissionRequestError, SubmissionError
+from submissions.team_api import get_team_ids_by_team_submission_uuid, get_team_submission
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
-from submissions.api import get_student_ids_by_submission_uuid, get_submission
-from submissions.team_api import get_team_ids_by_team_submission_uuid, get_team_submission
-from submissions.errors import SubmissionInternalError, SubmissionNotFoundError, SubmissionRequestError, SubmissionError
 
 from openassessment.assessment.models.base import Assessment, AssessmentPart
 from openassessment.assessment.models.staff import StaffWorkflow, TeamStaffWorkflow
-from openassessment.data import map_anonymized_ids_to_usernames
+from openassessment.data import map_anonymized_ids_to_usernames, OraSubmissionAnswerFactory, VersionNotFoundException
 from openassessment.staffgrader.errors.submission_lock import SubmissionLockContestedError
 from openassessment.staffgrader.models.submission_lock import SubmissionGradingLock
 from openassessment.staffgrader.serializers import (
@@ -24,9 +23,9 @@ from openassessment.staffgrader.serializers import (
     SubmissionDetailFileSerilaizer,
     SubmissionListSerializer,
     SubmissionLockSerializer,
+    TeamSubmissionListSerializer,
 )
 from openassessment.xblock.staff_area_mixin import require_course_staff
-from openassessment.data import OraSubmissionAnswerFactory, VersionNotFoundException
 
 
 log = logging.getLogger(__name__)

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -318,7 +318,10 @@ class StaffGraderMixin:
         }
         """
         try:
-            submission = get_submission(submission_uuid)
+            if self.is_team_assignment():
+                submission = get_team_submission(submission_uuid)
+            else:
+                submission = get_submission(submission_uuid)
             answer = OraSubmissionAnswerFactory.parse_submission_raw_answer(submission.get('answer'))
         except SubmissionError as err:
             raise JsonHandlerError(404, str(err)) from err

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -10,7 +10,7 @@ from openassessment.staffgrader.serializers.submission_list import TeamSubmissio
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 from submissions.api import get_student_ids_by_submission_uuid, get_submission
-from submissions.team_api import get_team_ids_by_team_submission_uuid , get_team_submission
+from submissions.team_api import get_team_ids_by_team_submission_uuid, get_team_submission
 from submissions.errors import SubmissionInternalError, SubmissionNotFoundError, SubmissionRequestError, SubmissionError
 
 from openassessment.assessment.models.base import Assessment, AssessmentPart

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -9,6 +9,7 @@ from django.db.models.fields import CharField
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 from submissions.api import get_student_ids_by_submission_uuid, get_submission
+from submissions.team_api import get_team_submission
 from submissions.errors import SubmissionInternalError, SubmissionNotFoundError, SubmissionRequestError, SubmissionError
 
 from openassessment.assessment.models.base import Assessment, AssessmentPart
@@ -50,7 +51,10 @@ def require_submission_uuid(validate=True):
                 raise JsonHandlerError(400, "Body must contain a submission_uuid")
             if validate:
                 try:
-                    get_submission(submission_uuid)
+                    if self.is_team_assignment():
+                        get_team_submission(submission_uuid)
+                    else:
+                        get_submission(submission_uuid)
                 except SubmissionNotFoundError as exc:
                     raise JsonHandlerError(404, "Submission not found") from exc
                 except SubmissionRequestError as exc:

--- a/openassessment/staffgrader/tests/test_list_staff_workflows.py
+++ b/openassessment/staffgrader/tests/test_list_staff_workflows.py
@@ -419,7 +419,7 @@ class StaffWorkflowListViewTeamTests(TestStaffWorkflowListViewBase):
         self.set_team_assignment(xblock)
 
         mock_get_team_ids_by_submission.return_value = self.team_ids_by_submission_id
-        # pylint: disable=unused-argument
+        # pylint: disable=unused-argument, protected-access
         xblock.runtime._services['teams'] = Mock(get_team_names=lambda a, b: self.team_names_by_team_id)
         with self._mock_map_anonymized_ids_to_usernames():
             response = self.request(xblock, 'list_staff_workflows', "{}", response_format='response')

--- a/openassessment/staffgrader/tests/test_list_staff_workflows.py
+++ b/openassessment/staffgrader/tests/test_list_staff_workflows.py
@@ -14,7 +14,12 @@ from submissions import api as sub_api
 from openassessment.assessment.models.base import Assessment
 from openassessment.staffgrader.models import SubmissionGradingLock
 from openassessment.tests.factories import (
-    AssessmentFactory, AssessmentPartFactory, CriterionOptionFactory, CriterionFactory, StaffWorkflowFactory, TeamStaffWorkflowFactory
+    AssessmentFactory,
+    AssessmentPartFactory,
+    CriterionOptionFactory,
+    CriterionFactory,
+    StaffWorkflowFactory,
+    TeamStaffWorkflowFactory,
 )
 import openassessment.workflow.api as workflow_api
 from openassessment.xblock.test.base import XBlockHandlerTestCase, scenario
@@ -333,6 +338,7 @@ class StaffWorkflowListViewIntegrationTests(TestStaffWorkflowListViewBase):
             response.decode('utf-8')
         )
 
+
 @ddt.ddt
 class StaffWorkflowListViewTeamTests(TestStaffWorkflowListViewBase):
     """
@@ -403,8 +409,7 @@ class StaffWorkflowListViewTeamTests(TestStaffWorkflowListViewBase):
 
     @patch('openassessment.staffgrader.staff_grader_mixin.get_team_ids_by_team_submission_uuid')
     @scenario('data/team_submission.xml', user_id=STAFF_ID)
-    def test_teams(self, xblock, mock_get_team_ids_by_submission): # mock_fetch_workflows, mock_get_serializer_context,
-
+    def test_teams(self, xblock, mock_get_team_ids_by_submission):
         self.set_staff_user(xblock)
         mock_get_team_ids_by_submission.return_value = self.team_ids_by_submission_id
         # pylint: disable=unused-argument

--- a/openassessment/staffgrader/tests/test_list_staff_workflows.py
+++ b/openassessment/staffgrader/tests/test_list_staff_workflows.py
@@ -14,7 +14,7 @@ from submissions import api as sub_api
 from openassessment.assessment.models.base import Assessment
 from openassessment.staffgrader.models import SubmissionGradingLock
 from openassessment.tests.factories import (
-    AssessmentFactory, AssessmentPartFactory, CriterionOptionFactory, CriterionFactory, StaffWorkflowFactory
+    AssessmentFactory, AssessmentPartFactory, CriterionOptionFactory, CriterionFactory, StaffWorkflowFactory, TeamStaffWorkflowFactory
 )
 import openassessment.workflow.api as workflow_api
 from openassessment.xblock.test.base import XBlockHandlerTestCase, scenario
@@ -43,6 +43,7 @@ TEST_START_DATE = SUBMITTED_DATE + timedelta(days=2)
 POINTS_POSSIBLE = 6
 
 TestUser = namedtuple("TestUser", ['username', 'student_id', 'submission'])
+TestTeam = namedtuple("TestTeam", ['team_name', 'team_id', 'member_ids', 'team_submission'])
 MockAnnotatedStaffWorkflow = namedtuple("MockAnnotatedStaffWorkflow", EXPECTED_ANNOTATED_WORKFLOW_FIELDS)
 
 
@@ -170,6 +171,7 @@ class TestStaffWorkflowListViewBase(XBlockHandlerTestCase):
         self,
         expected_response,
         student,
+        team=None,
         requester=None,
         date_graded=None,
         graded_by=None,
@@ -181,6 +183,7 @@ class TestStaffWorkflowListViewBase(XBlockHandlerTestCase):
         Params:
          - expected_reponse: The dict to append to
          - student: The student whose submission we're interested in
+         - team: The team whose submission we're interested in (ONLY FOR TEAM ASSIGNMENTS)
          - requester: The user requesting the list (needed for "locked" vs "in-progress") [defaults to staff_0]
          - date_graded: expected date the submission was graded [defaults to TEST_START_DATE if graded_by is non-null]
          - graded_by: expected user who created the assessment for the given submission
@@ -206,17 +209,20 @@ class TestStaffWorkflowListViewBase(XBlockHandlerTestCase):
                 'pointsEarned': expected_score,
             }
         expected_val = {
-            'submissionUuid': student.submission['uuid'],
+            'submissionUuid': student.submission['uuid'] if not team else team.team_submission,
             'dateSubmitted': str(SUBMITTED_DATE),
             'dateGraded': str(date_graded),
             'gradedBy': graded_by.username if graded_by else None,
             'gradingStatus': 'ungraded' if not date_graded else 'graded',
             'lockStatus': lock_status,
-            'username': student.username,
+            'username': student.username if not team else None,
+            'teamName': team.team_name if team else None,
             'score': score,
         }
 
-        expected_response[student.submission['uuid']] = expected_val
+        expected_response[
+            student.submission['uuid'] if not team else team.team_submission
+        ] = expected_val
 
     def setup_completed_assessments(self, xblock, grading_config):
         """
@@ -327,18 +333,96 @@ class StaffWorkflowListViewIntegrationTests(TestStaffWorkflowListViewBase):
             response.decode('utf-8')
         )
 
+@ddt.ddt
+class StaffWorkflowListViewTeamTests(TestStaffWorkflowListViewBase):
+    """
+    A few tests on top of existing tests to exercise teams functionality
+    """
+
+    @classmethod
+    def _create_test_team(cls, identifier, team_member_ids, create_submission=True):
+        """Create a TestTeam, linking team members to a team ID, name, and possible team submission"""
+        course_id = STUDENT_ITEM['course_id']
+        item_id = STUDENT_ITEM['item_id']
+        team_id = f"team_{identifier}_id"
+
+        if create_submission:
+            workflow = TeamStaffWorkflowFactory.create(course_id=course_id, item_id=item_id)
+            team_submission = workflow.team_submission_uuid
+        else:
+            team_submission = None
+
+        return TestTeam(
+            team_name=f"team_{identifier}_name",
+            team_id=team_id,
+            member_ids=team_member_ids,
+            team_submission=team_submission
+        )
+
+    @classmethod
+    @freeze_time(SUBMITTED_DATE)
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.course_id = STUDENT_ITEM['course_id']
+        cls.item_id = STUDENT_ITEM['item_id']
+
+        # Create four TestUser learners *without* submissions
+        cls.students = [
+            cls._create_test_user(identifier, "learner", create_submission=False)
+            for identifier in range(4)
+        ]
+
+        # Create three TestUsers to represent course staff
+        cls.course_staff = [
+            cls._create_test_user(identifier, "staff", create_submission=False)
+            for identifier in range(3)
+        ]
+
+        # Create 2 teams with submissions, the first two students on 1 team, the second on another
+        cls.teams = [
+            cls._create_test_team(0, [student.student_id for student in cls.students[0:2]]),
+            cls._create_test_team(1, [student.student_id for student in cls.students[2:2]])
+        ]
+
+        # When we're mocking `get_team_ids_by_team_submission_uuid` and `get_team_names`,
+        # we'll need these two dicts, so just set them up now.
+        cls.team_ids_by_submission_id = {
+            team.team_submission: team.team_id
+            for team in cls.teams
+        }
+        cls.team_names_by_team_id = {
+            team.team_id: team.team_name
+            for team in cls.teams
+        }
+
+        # Team assignments still need anon ID to username mappings for scorers
+        cls.student_id_to_username_map = {
+            test_user.student_id: test_user.username
+            for test_user in cls.course_staff
+        }
+
+    @patch('openassessment.staffgrader.staff_grader_mixin.get_team_ids_by_team_submission_uuid')
     @scenario('data/team_submission.xml', user_id=STAFF_ID)
-    def test_teams(self, xblock):
+    def test_teams(self, xblock, mock_get_team_ids_by_submission): # mock_fetch_workflows, mock_get_serializer_context,
+
         self.set_staff_user(xblock)
+        mock_get_team_ids_by_submission.return_value = self.team_ids_by_submission_id
+        # pylint: disable=unused-argument
+        xblock.runtime._services['teams'] = Mock(get_team_names=lambda a, b: self.team_names_by_team_id)
+
         with patch.object(xblock, 'is_team_assignment', return_value=True):
-            response = self.request(xblock, 'list_staff_workflows', "{}", response_format='response')
+            # with patch.object(xblock, 'teams_service.get_team_names', return_value=self.team_names_by_team_id):
+            with self._mock_map_anonymized_ids_to_usernames():
+                response = self.request(xblock, 'list_staff_workflows', "{}", response_format='response')
+
         response_body = json.loads(response.body.decode('utf-8'))
 
-        self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(
-            response_body,
-            {"error": "Team Submissions not currently supported"}
-        )
+        self.assertEqual(response.status_code, 200)
+
+        expected_response = {}
+        for team in self.teams:
+            self.add_expected_response_dict(expected_response, None, team=team)
+        self.assertDictEqual(response_body, expected_response)
 
 
 @ddt.ddt

--- a/openassessment/staffgrader/tests/test_serializers.py
+++ b/openassessment/staffgrader/tests/test_serializers.py
@@ -446,7 +446,7 @@ class TestTeamSubmissionListSerializer(BaseSerializerTest):
 
         with self.mock_serializer_methods(username=True, gradedBy=True, score=True, verify=True):
             with self.assertRaises(MissingContextException):
-                TeamSubmissionListSerializer(mock_workflow, context=context).data
+                _ = TeamSubmissionListSerializer(mock_workflow, context=context).data
 
     def test_integration(self):
         """Simple integration test to see that fields map correctly"""

--- a/openassessment/staffgrader/tests/test_serializers.py
+++ b/openassessment/staffgrader/tests/test_serializers.py
@@ -3,6 +3,7 @@ Tests for serializers used in staff grading
 """
 from contextlib import contextmanager, ExitStack
 from datetime import datetime, timedelta, timezone
+import enum
 from typing import OrderedDict
 from uuid import uuid4
 
@@ -12,7 +13,7 @@ from freezegun import freeze_time
 from mock import Mock, patch
 
 from openassessment.staffgrader.serializers.submission_list import (
-    SubmissionListSerializer, SubmissionListScoreSerializer
+    SubmissionListSerializer, SubmissionListScoreSerializer, TeamSubmissionListSerializer
 )
 from openassessment.staffgrader.models.submission_lock import SubmissionGradingLock
 from openassessment.staffgrader.serializers.submission_lock import SubmissionLockSerializer
@@ -118,6 +119,11 @@ class TestSubmissionListSerializer(BaseSerializerTest):
             yield
 
     @contextmanager
+    def mock_get_teamName(self):
+        with patch.object(SubmissionListSerializer, 'get_teamName', return_value='get_teamName'):
+            yield
+
+    @contextmanager
     def mock_get_score(self):
         with patch.object(SubmissionListSerializer, 'get_score', return_value='get_score'):
             yield
@@ -128,12 +134,14 @@ class TestSubmissionListSerializer(BaseSerializerTest):
             yield
 
     @contextmanager
-    def mock_serializer_methods(self, gradedBy=False, username=False, score=False, verify=False):
+    def mock_serializer_methods(self, gradedBy=False, username=False, teamName=False, score=False, verify=False):
         with ExitStack() as stack:
             if gradedBy:
                 stack.enter_context(self.mock_get_gradedBy())
             if username:
                 stack.enter_context(self.mock_get_username())
+            if teamName:
+                stack.enter_context(self.mock_get_teamName())
             if score:
                 stack.enter_context(self.mock_get_score())
             if verify:
@@ -142,7 +150,7 @@ class TestSubmissionListSerializer(BaseSerializerTest):
 
     def test_serializer(self):
         mock_workflow = Mock()
-        with self.mock_serializer_methods(gradedBy=True, username=True, score=True, verify=True):
+        with self.mock_serializer_methods(gradedBy=True, username=True, teamName=True, score=True, verify=True):
             result = SubmissionListSerializer(mock_workflow).data
         self.assertDictEqual(
             result,
@@ -154,6 +162,7 @@ class TestSubmissionListSerializer(BaseSerializerTest):
                 'lockStatus': str(mock_workflow.lock_status),
                 'gradedBy': 'get_gradedBy',
                 'username': 'get_username',
+                'teamName': 'get_teamName',
                 'score': 'get_score',
             }
         )
@@ -222,6 +231,22 @@ class TestSubmissionListSerializer(BaseSerializerTest):
 
         self.assertEqual(result['username'], username)
 
+    def test_get_teamName(self):
+        mock_workflow = Mock()
+        student_id, username = 'test_student_id', 'test_username'
+
+        with self.mock_serializer_methods(gradedBy=True, username=True, score=True, verify=True):
+            result = SubmissionListSerializer(
+                mock_workflow,
+                context={
+                    'submission_uuid_to_student_id': {mock_workflow.identifying_uuid: student_id},
+                    'anonymous_id_to_username': {student_id: username}
+                }
+            ).data
+
+        # Team name should always be none for this individual responses
+        self.assertEqual(result['teamName'], None)
+
     def test_integration(self):
         # Make three workflows. The first two have scorer_ids and the third does not
         workflows = [
@@ -270,6 +295,7 @@ class TestSubmissionListSerializer(BaseSerializerTest):
                 'lockStatus': str(workflows[0].lock_status),
                 'gradedBy': 'staff_username_1',
                 'username': 'username_0',
+                'teamName': None,
                 'score': {
                     'pointsEarned': 10,
                     'pointsPossible': 20,
@@ -283,6 +309,7 @@ class TestSubmissionListSerializer(BaseSerializerTest):
                 'lockStatus': str(workflows[1].lock_status),
                 'gradedBy': 'staff_username_2',
                 'username': 'username_1',
+                'teamName': None,
                 'score': {
                     'pointsEarned': 7,
                     'pointsPossible': 20,
@@ -296,6 +323,189 @@ class TestSubmissionListSerializer(BaseSerializerTest):
                 'lockStatus': str(workflows[2].lock_status),
                 'gradedBy': None,
                 'username': 'username_2',
+                'teamName': None,
+                'score': {},
+            })
+        ]
+
+        self.assertEqual(data, expected_data)
+
+@ddt.ddt
+class TestTeamSubmissionListSerializer(BaseSerializerTest):
+    """Tests for serializing a list of team submissions"""
+
+    @contextmanager
+    def mock_get_gradedBy(self):
+        with patch.object(TeamSubmissionListSerializer, 'get_gradedBy', return_value='get_gradedBy'):
+            yield
+
+    @contextmanager
+    def mock_get_username(self):
+        with patch.object(TeamSubmissionListSerializer, 'get_username', return_value='get_username'):
+            yield
+
+    @contextmanager
+    def mock_get_teamName(self):
+        with patch.object(TeamSubmissionListSerializer, 'get_teamName', return_value='get_teamName'):
+            yield
+
+    @contextmanager
+    def mock_get_score(self):
+        with patch.object(TeamSubmissionListSerializer, 'get_score', return_value='get_score'):
+            yield
+
+    @contextmanager
+    def mock_verify_required_context(self):
+        with patch.object(TeamSubmissionListSerializer, '_verify_required_context'):
+            yield
+
+    @contextmanager
+    def mock_serializer_methods(self, gradedBy=False, username=False, teamName=False, score=False, verify=False):
+        with ExitStack() as stack:
+            if gradedBy:
+                stack.enter_context(self.mock_get_gradedBy())
+            if username:
+                stack.enter_context(self.mock_get_username())
+            if teamName:
+                stack.enter_context(self.mock_get_teamName())
+            if score:
+                stack.enter_context(self.mock_get_score())
+            if verify:
+                stack.enter_context(self.mock_verify_required_context())
+            yield
+
+    def test_serializer(self):
+        """Test connections between serializer fields and underlying functions"""
+        mock_workflow = Mock()
+        with self.mock_serializer_methods(gradedBy=True, username=True, teamName=True, score=True, verify=True):
+            result = TeamSubmissionListSerializer(mock_workflow).data
+        self.assertDictEqual(
+            result,
+            {
+                'submissionUuid': str(mock_workflow.submission_uuid),
+                'dateSubmitted': str(mock_workflow.created_at),
+                'dateGraded': str(mock_workflow.grading_completed_at),
+                'gradingStatus': str(mock_workflow.grading_status),
+                'lockStatus': str(mock_workflow.lock_status),
+                'gradedBy': 'get_gradedBy',
+                'username': 'get_username',
+                'teamName': 'get_teamName',
+                'score': 'get_score',
+            }
+        )
+
+    def test_get_username(self):
+        mock_workflow = Mock()
+        student_id, username = 'test_student_id', 'test_username'
+
+        with self.mock_serializer_methods(teamName=True, gradedBy=True, score=True, verify=True):
+            result = TeamSubmissionListSerializer(
+                mock_workflow,
+                context={
+                    'submission_uuid_to_student_id': {mock_workflow.identifying_uuid: student_id},
+                    'anonymous_id_to_username': {student_id: username}
+                }
+            ).data
+
+        # Username should be null for team submissions
+        self.assertEqual(result['username'], None)
+
+    def test_get_teamName(self):
+        mock_workflow = Mock()
+        team_id, team_name = 'test_team_id', 'test_team_name'
+
+        with self.mock_serializer_methods(gradedBy=True, username=True, score=True, verify=True):
+            result = TeamSubmissionListSerializer(
+                mock_workflow,
+                context={
+                    'team_submission_uuid_to_team_id': {mock_workflow.identifying_uuid: team_id},
+                    'team_id_to_team_name': {team_id: team_name}
+                }
+            ).data
+
+        self.assertEqual(result['teamName'], team_name)
+
+    def test_integration(self):
+        """Simple integration test to see that fields map correctly"""
+        # Create 3 workflows, 2 have scorers
+        workflows = [
+            Mock(scorer_id='staff_student_id_1'),
+            Mock(scorer_id='staff_student_id_2'),
+            Mock(scorer_id=None)
+        ]
+
+        # Dict from workflow uuids to team_id_{0,1,2}
+        team_submission_uuid_to_team_id = {
+            workflow.identifying_uuid: f'team_id_{i}'
+            for i, workflow in enumerate(workflows)
+        }
+
+        # Add mappings from team ID to team name
+        team_id_to_team_name = {
+            f'team_id_{i}': f'Team name {i}'
+            for i, _ in enumerate(workflows)
+        }
+
+        # Anonymous id to username used only for scorer ids
+        anonymous_id_to_username = {}
+        anonymous_id_to_username[workflows[0].scorer_id] = 'staff_username_1'
+        anonymous_id_to_username[workflows[1].scorer_id] = 'staff_username_2'
+
+        # Add assessments for the "scored" workflows
+        submission_uuid_to_assessment = {
+            workflows[0].identifying_uuid: Mock(points_possible=20, points_earned=10),
+            workflows[1].identifying_uuid: Mock(points_possible=20, points_earned=7),
+        }
+
+        data = TeamSubmissionListSerializer(
+            workflows,
+            context={
+                'anonymous_id_to_username': anonymous_id_to_username,
+                'submission_uuid_to_assessment': submission_uuid_to_assessment,
+                'team_submission_uuid_to_team_id': team_submission_uuid_to_team_id,
+                'team_id_to_team_name': team_id_to_team_name,
+            },
+            many=True
+        ).data
+
+        expected_data = [
+            OrderedDict({
+                'submissionUuid': str(workflows[0].submission_uuid),
+                'dateSubmitted': str(workflows[0].created_at),
+                'dateGraded': str(workflows[0].grading_completed_at),
+                'gradingStatus': str(workflows[0].grading_status),
+                'lockStatus': str(workflows[0].lock_status),
+                'gradedBy': 'staff_username_1',
+                'username': None,
+                'teamName': 'Team name 0',
+                'score': {
+                    'pointsEarned': 10,
+                    'pointsPossible': 20,
+                },
+            }),
+            OrderedDict({
+                'submissionUuid': str(workflows[1].submission_uuid),
+                'dateSubmitted': str(workflows[1].created_at),
+                'dateGraded': str(workflows[1].grading_completed_at),
+                'gradingStatus': str(workflows[1].grading_status),
+                'lockStatus': str(workflows[1].lock_status),
+                'gradedBy': 'staff_username_2',
+                'username': None,
+                'teamName': 'Team name 1',
+                'score': {
+                    'pointsEarned': 7,
+                    'pointsPossible': 20,
+                },
+            }),
+            OrderedDict({
+                'submissionUuid': str(workflows[2].submission_uuid),
+                'dateSubmitted': str(workflows[2].created_at),
+                'dateGraded': str(workflows[2].grading_completed_at),
+                'gradingStatus': str(workflows[2].grading_status),
+                'lockStatus': str(workflows[2].lock_status),
+                'gradedBy': None,
+                'username': None,
+                'teamName': 'Team name 2',
                 'score': {},
             })
         ]

--- a/openassessment/staffgrader/tests/test_serializers.py
+++ b/openassessment/staffgrader/tests/test_serializers.py
@@ -3,7 +3,6 @@ Tests for serializers used in staff grading
 """
 from contextlib import contextmanager, ExitStack
 from datetime import datetime, timedelta, timezone
-import enum
 from typing import OrderedDict
 from uuid import uuid4
 

--- a/openassessment/staffgrader/tests/test_serializers.py
+++ b/openassessment/staffgrader/tests/test_serializers.py
@@ -376,7 +376,7 @@ class TestTeamSubmissionListSerializer(BaseSerializerTest):
                 stack.enter_context(self.mock_verify_required_context())
             yield
 
-    @ddt.data(0,1,2,3)
+    @ddt.data(0, 1, 2, 3)
     def test_missing_context(self, key_to_remove):
         """Test that missing context raises an exception"""
         context = {key: {} for key in self.required_context_keys}
@@ -442,7 +442,7 @@ class TestTeamSubmissionListSerializer(BaseSerializerTest):
 
     def test_get_teamName_missing_context(self):
         mock_workflow = Mock()
-        context={}
+        context = {}
 
         with self.mock_serializer_methods(username=True, gradedBy=True, score=True, verify=True):
             with self.assertRaises(MissingContextException):

--- a/openassessment/staffgrader/tests/test_serializers.py
+++ b/openassessment/staffgrader/tests/test_serializers.py
@@ -330,6 +330,7 @@ class TestSubmissionListSerializer(BaseSerializerTest):
 
         self.assertEqual(data, expected_data)
 
+
 @ddt.ddt
 class TestTeamSubmissionListSerializer(BaseSerializerTest):
     """Tests for serializing a list of team submissions"""

--- a/openassessment/staffgrader/tests/test_serializers.py
+++ b/openassessment/staffgrader/tests/test_serializers.py
@@ -382,7 +382,7 @@ class TestTeamSubmissionListSerializer(BaseSerializerTest):
         self.assertDictEqual(
             result,
             {
-                'submissionUuid': str(mock_workflow.submission_uuid),
+                'submissionUuid': str(mock_workflow.team_submission_uuid),
                 'dateSubmitted': str(mock_workflow.created_at),
                 'dateGraded': str(mock_workflow.grading_completed_at),
                 'gradingStatus': str(mock_workflow.grading_status),
@@ -470,7 +470,7 @@ class TestTeamSubmissionListSerializer(BaseSerializerTest):
 
         expected_data = [
             OrderedDict({
-                'submissionUuid': str(workflows[0].submission_uuid),
+                'submissionUuid': str(workflows[0].team_submission_uuid),
                 'dateSubmitted': str(workflows[0].created_at),
                 'dateGraded': str(workflows[0].grading_completed_at),
                 'gradingStatus': str(workflows[0].grading_status),
@@ -484,7 +484,7 @@ class TestTeamSubmissionListSerializer(BaseSerializerTest):
                 },
             }),
             OrderedDict({
-                'submissionUuid': str(workflows[1].submission_uuid),
+                'submissionUuid': str(workflows[1].team_submission_uuid),
                 'dateSubmitted': str(workflows[1].created_at),
                 'dateGraded': str(workflows[1].grading_completed_at),
                 'gradingStatus': str(workflows[1].grading_status),
@@ -498,7 +498,7 @@ class TestTeamSubmissionListSerializer(BaseSerializerTest):
                 },
             }),
             OrderedDict({
-                'submissionUuid': str(workflows[2].submission_uuid),
+                'submissionUuid': str(workflows[2].team_submission_uuid),
                 'dateSubmitted': str(workflows[2].created_at),
                 'dateGraded': str(workflows[2].grading_completed_at),
                 'gradingStatus': str(workflows[2].grading_status),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='4.0.2',
+    version='4.0.3',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** tweaks to support team assignments in ESG.

JIRA: [AU-493](https://openedx.atlassian.net/browse/AU-493)

**NOTE** refactoring work for team grade submit split into [AU-539](https://openedx.atlassian.net/browse/AU-539)

**What changed?**
- Update `@require_submission_uuid` to validate team submission UUID when assignment is a team assignment
- Update endpoints for team submissions
    - `list_staff_workflows` now return team assignment metadata correctly
    - `get_submission_info` and `get_assessment_info` now do correct lookup for team assignments
- Create `TeamSubmissionListSerializer` based on `SubmissionListSerializer` to be able to serialize team assignments
    -  For team assignments, `username` is `None`, `teamName` gets the name of the submitting team.
    - For team assignments, `submissionUuid` is the team submission UUID
- Update `SubmissionListSerializer` to pass `teamName` key with value `None`
- Update to new `edx-submissions` version `3.5.1` to fix team ID lookup bug.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [x] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- [ ] Exercise endpoints with postman collection (query params all stay the same, just set `oraLocation` value to a team ORA block and `submissionUUID` to a team submission UUID).
- [ ] Integration test with ESG

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
