### PR TITLE
fix: added _size to the report generator for problem responses

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -582,7 +582,7 @@ class OraAggregateData:
 
         from openassessment.xblock.openassessmentblock import OpenAssessmentBlock
         file_downloads = OpenAssessmentBlock.get_download_urls_from_submission(submission)
-        for url, _description, _filename, _show_delete in file_downloads:
+        for url, _description, _filename, _size, _show_delete in file_downloads:
             if file_links:
                 file_links += sep
             file_links += urljoin(base_url, url)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "3.8.2",
+  "version": "4.0.1",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='4.0.0',
+    version='4.0.1',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** A new parameter was added to the dict and caused the celery task to fail when generating the report

JIRA: [AU-522](https://openedx.atlassian.net/browse/AU-522)

**What changed?**

Added the _size value to be processed

**Developer Checklist**
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

Working on testing it locally in DevStack.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
