### PR TITLE
feat: ESG submit grade for teams

### DIFF
--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -390,3 +390,35 @@ class StaffGraderMixin:
 
         assessment = assessments[submission_uuid]
         return AssessmentSerializer(assessment).data
+
+    @XBlock.json_handler
+    @require_course_staff("STUDENT_GRADE")
+    @require_submission_uuid(validate=True)
+    def submit_staff_assessment(self, submission_uuid, data, suffix=''):  # pylint: disable=unused-argument
+        """
+        Staff grader-specific wrapper over staff assessments to better handle individual vs team assignments
+
+        data: { (grade data)
+            'options_selected': {
+                '<criterion_name_1>': <selected_option_name>,
+                '<criterion_name_2>': <selected_option_name>,
+            },
+            'criterion_feedback': {
+                '<criterion_label_1>': (string)
+            },
+            'overall_feedback': (string)
+            'submission_uuid': (string)
+            'assess_type': (string) one of ['regrade', full-grade']
+        }
+
+        Returns: (note that I wanna change this) {
+            'success': True/False - whether or not the grade submit succeeded
+            'msg': String/Empty - error string, if failure occurred
+        }
+        """
+        if self.is_team_assignment():
+            success, err_msg = self.do_team_staff_assessment(data, team_submission_uuid=submission_uuid)
+        else:
+            success, err_msg = self.do_staff_assessment(data)
+
+        return {'success': success, 'msg': err_msg}

--- a/openassessment/staffgrader/tests/test_base.py
+++ b/openassessment/staffgrader/tests/test_base.py
@@ -114,5 +114,5 @@ class StaffGraderMixinTestBase(XBlockHandlerTestCase):
             'submission_uuid': submission_uuid
         }
         self.set_staff_user(xblock, grader)
-        resp = super().request(xblock, 'staff_assess', json.dumps(assessment), response_format='json')
+        resp = super().request(xblock, 'submit_staff_assessment', json.dumps(assessment), response_format='json')
         self.assertTrue(resp['success'])

--- a/openassessment/staffgrader/tests/test_list_staff_workflows.py
+++ b/openassessment/staffgrader/tests/test_list_staff_workflows.py
@@ -174,7 +174,7 @@ class TestStaffWorkflowListViewBase(XBlockHandlerTestCase):
             'submission_uuid': student.submission['uuid']
         }
         self.set_staff_user(xblock, user=grader)
-        resp = self.request(xblock, 'staff_assess', json.dumps(assessment), response_format='json')
+        resp = self.request(xblock, 'submit_staff_assessment', json.dumps(assessment), response_format='json')
         self.assertTrue(resp['success'])
 
     def add_expected_response_dict(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='4.0.3',
+    version='4.0.4',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** Create ESG grading endpoint to allow us to submit a grade against a team submission UUID or individual submission UUID, based on the ORA type.

JIRA: [AU-539](https://openedx.atlassian.net/browse/AU-539)
Supports dependent PR #?????

**What changed?**

Team ORAs currently submit grades based off the example individual submission UUID that staff is viewing, looking up the team to submit for the other members. In ESG, we want to operate only with the team submission UUID when we're on a team ORA. Added the following changes and refactors to support this:

- Create new `XBlock.json_handler`, `submit_staff_assessment` (a light modification of existing `staff_assess` endpoint) designed for ESG use (see PR #????? for updated BFF mappings)
- ^ Allows us to submit an assessment against a team submission UUID directly instead of an individual UUID with a team lookup from that.
- `staff_assess` endpoint maintains existing structure of submitting against individual UUID and, if it is a team assignment, lookup of team submission UUID.
- Underlying refactors to support those changes.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- [ ] Exercise new `submit_staff_assessment` on individual and team ORAs to verify grading works as expected.
- [ ] Exercise existing `staff_assess` in LMS or Postman to verify no regression issues.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
