### PR TITLE
feat: bulk delete submission locks

### DIFF
--- a/openassessment/staffgrader/models/submission_lock.py
+++ b/openassessment/staffgrader/models/submission_lock.py
@@ -101,15 +101,7 @@ class SubmissionGradingLock(models.Model):
 
         Returns: None or raises DB error
         """
-        # Get a list of locks we own, filtered by the list we're requesting to clerar
-        locks_to_clear = cls.objects.filter(
+        return cls.objects.filter(
             submission_uuid__in=submission_uuids,
             owner_id=user_id
-        )
-
-        # return a list of submission UUIDs that are actually getting cleared
-        cleared_submission_lock_ids = [lock.submission_uuid for lock in locks_to_clear]
-
-        locks_to_clear.delete()
-
-        return cleared_submission_lock_ids
+        ).delete()

--- a/openassessment/staffgrader/models/submission_lock.py
+++ b/openassessment/staffgrader/models/submission_lock.py
@@ -102,6 +102,5 @@ class SubmissionGradingLock(models.Model):
         Returns: None or raises DB error
         """
         return cls.objects.filter(
-            submission_uuid__in=submission_uuids,
-            owner_id=user_id
+            submission_uuid__in=submission_uuids, owner_id=user_id
         ).delete()

--- a/openassessment/staffgrader/models/submission_lock.py
+++ b/openassessment/staffgrader/models/submission_lock.py
@@ -99,8 +99,8 @@ class SubmissionGradingLock(models.Model):
         """
         For a list of submission locks to try to clear, clear those that we own.
 
-        Returns: None or raises DB error
+        Returns: Number of submission locks cleared
         """
-        return cls.objects.filter(
+        cls.objects.filter(
             submission_uuid__in=submission_uuids, owner_id=user_id
-        ).delete()
+        ).delete()[0]

--- a/openassessment/staffgrader/models/submission_lock.py
+++ b/openassessment/staffgrader/models/submission_lock.py
@@ -93,3 +93,23 @@ class SubmissionGradingLock(models.Model):
             raise SubmissionLockContestedError
 
         current_lock.delete()
+
+    @classmethod
+    def batch_clear_submission_locks(cls, submission_uuids, user_id):
+        """
+        For a list of submission locks to try to clear, clear those that we own.
+
+        Returns: None or raises DB error
+        """
+        # Get a list of locks we own, filtered by the list we're requesting to clerar
+        locks_to_clear = cls.objects.filter(
+            submission_uuid__in=submission_uuids,
+            owner_id=user_id
+        )
+
+        # return a list of submission UUIDs that are actually getting cleared
+        cleared_submission_lock_ids = [lock.submission_uuid for lock in locks_to_clear]
+
+        locks_to_clear.delete()
+
+        return cleared_submission_lock_ids

--- a/openassessment/staffgrader/models/submission_lock.py
+++ b/openassessment/staffgrader/models/submission_lock.py
@@ -101,6 +101,6 @@ class SubmissionGradingLock(models.Model):
 
         Returns: Number of submission locks cleared
         """
-        cls.objects.filter(
+        return cls.objects.filter(
             submission_uuid__in=submission_uuids, owner_id=user_id
         ).delete()[0]

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -147,7 +147,7 @@ class StaffGraderMixin:
         anonymous_user_id = self.get_anonymous_user_id_from_xmodule_runtime()
         submission_uuids = data.get("submission_uuids")
 
-        if (not submission_uuids) or type(submission_uuids) is not list:
+        if (not submission_uuids) or isinstance(submission_uuids, list):
             raise JsonHandlerError(400, "Body must contain a submission_uuids list")
 
         try:

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -145,8 +145,7 @@ class StaffGraderMixin:
         - 500 for generic errors
         """
         submission_uuids = data.get("submission_uuids")
-
-        if (not submission_uuids) or not isinstance(submission_uuids, list):
+        if not isinstance(submission_uuids, list):
             raise JsonHandlerError(400, "Body must contain a submission_uuids list")
 
         anonymous_user_id = self.get_anonymous_user_id_from_xmodule_runtime()

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -147,7 +147,7 @@ class StaffGraderMixin:
         anonymous_user_id = self.get_anonymous_user_id_from_xmodule_runtime()
         submission_uuids = data.get("submission_uuids")
 
-        if (not submission_uuids) or isinstance(submission_uuids, list):
+        if (not submission_uuids) or not isinstance(submission_uuids, list):
             raise JsonHandlerError(400, "Body must contain a submission_uuids list")
 
         try:

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -138,9 +138,7 @@ class StaffGraderMixin:
         """
         Given a list of submission UUIDs, clear those that we currently have locks for.
 
-        Returns: {
-            'cleared_grading_locks': [uuid]
-        }
+        Returns: None, no errors is implicit success
 
         Raises:
         - 400 in the case of bad params/data
@@ -153,10 +151,7 @@ class StaffGraderMixin:
             raise JsonHandlerError(400, "Body must contain a submission_uuids list")
 
         try:
-            cleared_locks = SubmissionGradingLock.batch_clear_submission_locks(submission_uuids, anonymous_user_id)
-            return {
-                'cleared_grading_locks': [lock for lock in cleared_locks]
-            }
+            SubmissionGradingLock.batch_clear_submission_locks(submission_uuids, anonymous_user_id)
         except Exception as err:
             raise JsonHandlerError(500, str(err)) from err
 

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -145,13 +145,15 @@ class StaffGraderMixin:
         - 500 for generic errors
         """
         anonymous_user_id = self.get_anonymous_user_id_from_xmodule_runtime()
-        submission_uuids = data.get('submission_uuids')
+        submission_uuids = data.get("submission_uuids")
 
         if (not submission_uuids) or type(submission_uuids) is not list:
             raise JsonHandlerError(400, "Body must contain a submission_uuids list")
 
         try:
-            SubmissionGradingLock.batch_clear_submission_locks(submission_uuids, anonymous_user_id)
+            SubmissionGradingLock.batch_clear_submission_locks(
+                submission_uuids, anonymous_user_id
+            )
         except Exception as err:
             raise JsonHandlerError(500, str(err)) from err
 

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -144,11 +144,14 @@ class StaffGraderMixin:
         - 400 in the case of bad params/data
         - 500 for generic errors
         """
-        anonymous_user_id = self.get_anonymous_user_id_from_xmodule_runtime()
         submission_uuids = data.get("submission_uuids")
 
         if (not submission_uuids) or not isinstance(submission_uuids, list):
             raise JsonHandlerError(400, "Body must contain a submission_uuids list")
+
+        anonymous_user_id = self.get_anonymous_user_id_from_xmodule_runtime()
+        if not anonymous_user_id:
+            raise JsonHandlerError(500, "Failed to get anonymous user ID")
 
         try:
             SubmissionGradingLock.batch_clear_submission_locks(

--- a/openassessment/staffgrader/tests/test_staff_grader_mixin.py
+++ b/openassessment/staffgrader/tests/test_staff_grader_mixin.py
@@ -213,6 +213,23 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         })
 
     @scenario('data/basic_scenario.xml', user_id="staff")
+    def test_batch_delete_submission_locks_empty(self, xblock):
+        """ An empty list of submisison UUIDs is silly, but should pass """
+        xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
+
+        request_data = {'submission_uuids': []}
+        response = self.request(
+            xblock,
+            'batch_delete_submission_lock',
+            json.dumps(request_data),
+            response_format='response',
+        )
+        response_body = json.loads(response.body.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response_body)
+
+    @scenario('data/basic_scenario.xml', user_id="staff")
     def test_batch_delete_submission_locks_bad_param(self, xblock):
         """ Batch delete fails if submission_uuids is not a list """
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)

--- a/openassessment/staffgrader/tests/test_staff_grader_mixin.py
+++ b/openassessment/staffgrader/tests/test_staff_grader_mixin.py
@@ -210,9 +210,16 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         request_data = {'submission_uuids': [self.test_submission_uuid, self.test_other_submission_uuid]}
         response = self.request(xblock, 'batch_delete_submission_lock', json.dumps(request_data), response_format='json')
 
-        self.assertDictEqual(response, {
-            "cleared_grading_locks": [self.test_submission_uuid]
-        })
+        # Response should be empty on success
+        self.assertIsNone(response)
+
+        # Assert our lock was cleared and other individual's lock was not
+        assert not SubmissionGradingLock.objects.filter(
+            submission_uuid=self.test_submission_uuid
+        ).exists()
+        assert SubmissionGradingLock.objects.filter(
+            submission_uuid=self.test_other_submission_uuid
+        ).exists()
 
     @patch('openassessment.staffgrader.staff_grader_mixin.get_submission')
     @scenario('data/basic_scenario.xml', user_id="staff")

--- a/openassessment/staffgrader/tests/test_staff_grader_mixin.py
+++ b/openassessment/staffgrader/tests/test_staff_grader_mixin.py
@@ -19,6 +19,7 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
     test_submission_uuid = str(uuid4())
     test_submission_uuid_unlocked = str(uuid4())
     test_team_submission_uuid = str(uuid4())
+    test_other_submission_uuid = str(uuid4())
 
     test_timestamp = "1969-07-20T22:56:00-04:00"
 
@@ -26,6 +27,9 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
 
     staff_user = None
     staff_user_id = 'staff'
+
+    other_staff_user = None
+    other_staff_user_id = 'other-staff'
 
     non_staff_user = None
     non_staff_user_id = 'not-staff'
@@ -39,12 +43,17 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         cls.staff_user.is_staff = True
         cls.staff_user.save()
 
+        cls.other_staff_user = UserFactory.create()
+        cls.other_staff_user.is_staff = True
+        cls.other_staff_user.save()
+
         cls.non_staff_user = UserFactory.create()
         cls.non_staff_user.is_staff = False
         cls.non_staff_user.save()
 
         # Authenticate users - Fun fact, that's a Django typo :shrug:
         cls.staff_user.is_athenticated = True
+        cls.other_staff_user.is_athenticated = True
         cls.non_staff_user.is_athenticated = True
 
     def setUp(self):
@@ -54,6 +63,12 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         self.submission_lock = SubmissionGradingLock.objects.create(
             owner_id=self.staff_user_id,
             submission_uuid=self.test_submission_uuid,
+        )
+
+        # Create a submission lock owned by another user
+        self.other_submission_lock = SubmissionGradingLock.objects.create(
+            owner_id=self.other_staff_user_id,
+            submission_uuid=self.test_other_submission_uuid,
         )
 
     @scenario('data/basic_scenario.xml', user_id="staff")
@@ -157,6 +172,46 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         self.assertEqual(response.status_code, 403)
         self.assertDictEqual(response_body, {
             "error": "ERR_LOCK_CONTESTED"
+        })
+
+    @scenario('data/basic_scenario.xml', user_id="staff")
+    def test_batch_delete_submission_locks_no_param(self, xblock):
+        """ Batch delete fails if submission_uuids not supplied """
+        xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
+
+        request_data = {}
+        response = self.request(xblock, 'batch_delete_submission_lock', json.dumps(request_data), response_format='response')
+        response_body = json.loads(response.body.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertDictEqual(response_body, {
+            "error": "Body must contain a submission_uuids list"
+        })
+
+    @scenario('data/basic_scenario.xml', user_id="staff")
+    def test_batch_delete_submission_locks_bad_param(self, xblock):
+        """ Batch delete fails if submission_uuids is not a list """
+        xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
+
+        request_data = {'submission_uuids': 'foo'}
+        response = self.request(xblock, 'batch_delete_submission_lock', json.dumps(request_data), response_format='response')
+        response_body = json.loads(response.body.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertDictEqual(response_body, {
+            "error": "Body must contain a submission_uuids list"
+        })
+
+    @scenario('data/basic_scenario.xml', user_id="staff")
+    def test_batch_delete_submission_locks(self, xblock):
+        """ Batch delete clears submission locks we own """
+        xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
+
+        request_data = {'submission_uuids': [self.test_submission_uuid, self.test_other_submission_uuid]}
+        response = self.request(xblock, 'batch_delete_submission_lock', json.dumps(request_data), response_format='json')
+
+        self.assertDictEqual(response, {
+            "cleared_grading_locks": [self.test_submission_uuid]
         })
 
     @patch('openassessment.staffgrader.staff_grader_mixin.get_submission')

--- a/openassessment/staffgrader/tests/test_staff_grader_mixin.py
+++ b/openassessment/staffgrader/tests/test_staff_grader_mixin.py
@@ -180,7 +180,12 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
 
         request_data = {}
-        response = self.request(xblock, 'batch_delete_submission_lock', json.dumps(request_data), response_format='response')
+        response = self.request(
+            xblock,
+            'batch_delete_submission_lock',
+            json.dumps(request_data),
+            response_format='response',
+        )
         response_body = json.loads(response.body.decode('utf-8'))
 
         self.assertEqual(response.status_code, 400)
@@ -194,7 +199,12 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
 
         request_data = {'submission_uuids': 'foo'}
-        response = self.request(xblock, 'batch_delete_submission_lock', json.dumps(request_data), response_format='response')
+        response = self.request(
+            xblock,
+            'batch_delete_submission_lock',
+            json.dumps(request_data),
+            response_format='response',
+        )
         response_body = json.loads(response.body.decode('utf-8'))
 
         self.assertEqual(response.status_code, 400)
@@ -208,7 +218,12 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)
 
         request_data = {'submission_uuids': [self.test_submission_uuid, self.test_other_submission_uuid]}
-        response = self.request(xblock, 'batch_delete_submission_lock', json.dumps(request_data), response_format='json')
+        response = self.request(
+            xblock,
+            'batch_delete_submission_lock',
+            json.dumps(request_data),
+            response_format='json',
+        )
 
         # Response should be empty on success
         self.assertIsNone(response)

--- a/openassessment/staffgrader/tests/test_staff_grader_mixin.py
+++ b/openassessment/staffgrader/tests/test_staff_grader_mixin.py
@@ -175,6 +175,25 @@ class TestStaffGraderMixin(XBlockHandlerTestCase):
         })
 
     @scenario('data/basic_scenario.xml', user_id="staff")
+    def test_batch_delete_submission_locks_no_id(self, xblock):
+        """ If, somehow, the runtime fails to give us a user ID, break """
+        xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=None)
+
+        request_data = {'submission_uuids': ['foo']}
+        response = self.request(
+            xblock,
+            'batch_delete_submission_lock',
+            json.dumps(request_data),
+            response_format='response',
+        )
+        response_body = json.loads(response.body.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 500)
+        self.assertDictEqual(response_body, {
+            "error": "Failed to get anonymous user ID",
+        })
+
+    @scenario('data/basic_scenario.xml', user_id="staff")
     def test_batch_delete_submission_locks_no_param(self, xblock):
         """ Batch delete fails if submission_uuids not supplied """
         xblock.xmodule_runtime = Mock(user_is_staff=True, anonymous_student_id=self.staff_user_id)

--- a/openassessment/staffgrader/tests/test_submission_lock_model.py
+++ b/openassessment/staffgrader/tests/test_submission_lock_model.py
@@ -94,3 +94,52 @@ class TestSubmissionLockModel(TestCase):
         assert SubmissionGradingLock.get_submission_lock(self.locked_submission_uuid) == self.existing_submission_lock
         with self.assertRaises(SubmissionLockContestedError):
             SubmissionGradingLock.clear_submission_lock(self.locked_submission_uuid, self.other_user_id)
+
+    def test_batch_clear_submission_lock(self):
+        # batch_clear_submission_lock removes requested locks that the user owns
+        
+        # Create a bunch of submisison IDs
+        submission_ids = [uuid4() for _ in range(4)]
+
+        # Create lock owned by user to be cleared
+        SubmissionGradingLock.objects.create(
+            submission_uuid=submission_ids[0],
+            owner_id=self.user_id,
+            created_at=datetime.now(tz=timezone.utc)
+        )
+
+        # Create a second lock owned by user to be cleared
+        SubmissionGradingLock.objects.create(
+            submission_uuid=submission_ids[1],
+            owner_id=self.user_id,
+            created_at=datetime.now(tz=timezone.utc)
+        )
+
+        # Create lock owned by someone else to not be cleared
+        SubmissionGradingLock.objects.create(
+            submission_uuid=submission_ids[2],
+            owner_id=self.other_user_id,
+            created_at=datetime.now(tz=timezone.utc)
+        )
+
+        # Create lock owned by user to not be cleared
+        SubmissionGradingLock.objects.create(
+            submission_uuid=submission_ids[3],
+            owner_id=self.user_id,
+            created_at=datetime.now(tz=timezone.utc)
+        )
+ 
+        submission_ids_to_clear = [str(submission) for submission in submission_ids[0:3]]
+        cleared_locks = SubmissionGradingLock.batch_clear_submission_locks(submission_ids_to_clear, self.user_id)
+
+        # Assert DB queries
+
+        # Assert that the requested and allowed locks got cleared and returned
+        for submisison_id in submission_ids_to_clear[0:2]:
+            assert SubmissionGradingLock.get_submission_lock(submisison_id) is None
+            assert submisison_id in cleared_locks
+
+        # Assert that the remaining locks are untouched
+        for submisison_id in submission_ids_to_clear[2:4]:
+            assert SubmissionGradingLock.get_submission_lock(submisison_id) is not None
+            assert submisison_id not in cleared_locks

--- a/openassessment/staffgrader/tests/test_submission_lock_model.py
+++ b/openassessment/staffgrader/tests/test_submission_lock_model.py
@@ -97,7 +97,7 @@ class TestSubmissionLockModel(TestCase):
 
     def test_batch_clear_submission_lock(self):
         # batch_clear_submission_lock removes requested locks that the user owns
-        
+
         # Create a bunch of submisison IDs
         submission_ids = [uuid4() for _ in range(4)]
 
@@ -105,32 +105,36 @@ class TestSubmissionLockModel(TestCase):
         SubmissionGradingLock.objects.create(
             submission_uuid=submission_ids[0],
             owner_id=self.user_id,
-            created_at=datetime.now(tz=timezone.utc)
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         # Create a second lock owned by user to be cleared
         SubmissionGradingLock.objects.create(
             submission_uuid=submission_ids[1],
             owner_id=self.user_id,
-            created_at=datetime.now(tz=timezone.utc)
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         # Create lock owned by someone else to not be cleared
         SubmissionGradingLock.objects.create(
             submission_uuid=submission_ids[2],
             owner_id=self.other_user_id,
-            created_at=datetime.now(tz=timezone.utc)
+            created_at=datetime.now(tz=timezone.utc),
         )
 
         # Create lock owned by user to not be cleared
         SubmissionGradingLock.objects.create(
             submission_uuid=submission_ids[3],
             owner_id=self.user_id,
-            created_at=datetime.now(tz=timezone.utc)
+            created_at=datetime.now(tz=timezone.utc),
         )
- 
-        submission_ids_to_clear = [str(submission) for submission in submission_ids[0:3]]
-        SubmissionGradingLock.batch_clear_submission_locks(submission_ids_to_clear, self.user_id)
+
+        submission_ids_to_clear = [
+            str(submission) for submission in submission_ids[0:3]
+        ]
+        SubmissionGradingLock.batch_clear_submission_locks(
+            submission_ids_to_clear, self.user_id
+        )
 
         # Assert that the requested and allowed locks got cleared and returned
         for submission_id in submission_ids_to_clear[0:2]:

--- a/openassessment/staffgrader/tests/test_submission_lock_model.py
+++ b/openassessment/staffgrader/tests/test_submission_lock_model.py
@@ -130,16 +130,12 @@ class TestSubmissionLockModel(TestCase):
         )
  
         submission_ids_to_clear = [str(submission) for submission in submission_ids[0:3]]
-        cleared_locks = SubmissionGradingLock.batch_clear_submission_locks(submission_ids_to_clear, self.user_id)
-
-        # Assert DB queries
+        SubmissionGradingLock.batch_clear_submission_locks(submission_ids_to_clear, self.user_id)
 
         # Assert that the requested and allowed locks got cleared and returned
-        for submisison_id in submission_ids_to_clear[0:2]:
-            assert SubmissionGradingLock.get_submission_lock(submisison_id) is None
-            assert submisison_id in cleared_locks
+        for submission_id in submission_ids_to_clear[0:2]:
+            assert SubmissionGradingLock.get_submission_lock(submission_id) is None
 
         # Assert that the remaining locks are untouched
-        for submisison_id in submission_ids_to_clear[2:4]:
-            assert SubmissionGradingLock.get_submission_lock(submisison_id) is not None
-            assert submisison_id not in cleared_locks
+        for submission_id in submission_ids_to_clear[2:4]:
+            assert SubmissionGradingLock.get_submission_lock(submission_id) is not None

--- a/openassessment/staffgrader/tests/test_submission_lock_model.py
+++ b/openassessment/staffgrader/tests/test_submission_lock_model.py
@@ -132,9 +132,12 @@ class TestSubmissionLockModel(TestCase):
         submission_ids_to_clear = [
             str(submission) for submission in submission_ids[0:3]
         ]
-        SubmissionGradingLock.batch_clear_submission_locks(
+        count_cleared = SubmissionGradingLock.batch_clear_submission_locks(
             submission_ids_to_clear, self.user_id
         )
+
+        # API returns the number of records cleared
+        assert count_cleared == 2
 
         # Assert that the requested and allowed locks got cleared and returned
         for submission_id in submission_ids_to_clear[0:2]:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
 
 setup(
     name='ora2',
-    version='4.0.7',
+    version='4.1.0',
     author='edX',
     author_email='oscm@edx.org',
     url='http://github.com/edx/edx-ora2',


### PR DESCRIPTION
**TL;DR -** add an endpoint for bulk deletion of submission locks. Used when exiting the new staff grading experience to reset in-progress locks.

JIRA: [AU-592](https://openedx.atlassian.net/browse/AU-592)

**What changed?**

- Add new XBlock JSON handler, `batch_delete_submission_lock` which takes a `submission_uuids` list of locks to try to delete.
- Endpoint will delete any locks in that list that the user owns, ignoring any locks owned by other users.
- Response is silent, returns empty `200` on success, `400` for bad request and `500` for internal errors

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- [ ] Unit tests
- [ ] Create submission locks under several users (can use Django or existing JSON handler endpoints)
- [ ] Exercise the endpoint with a list of `submission_uuids` including some (but not all) of your active locks, with other locks that are not owned by you.
- [ ] Verify that only the requested locks that you own are cleared

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
