### PR TITLE
chore: ignore uncovered LMS import function from coverage

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -54,6 +54,7 @@ def _use_read_replica(queryset):
     )
 
 
+# pragma: no cover
 def _get_course_blocks(course_id):
     """
     Returns untransformed block structure for a given course key.

--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -54,8 +54,7 @@ def _use_read_replica(queryset):
     )
 
 
-# pragma: no cover
-def _get_course_blocks(course_id):
+def _get_course_blocks(course_id):  # pragma: no cover
     """
     Returns untransformed block structure for a given course key.
 


### PR DESCRIPTION
We're right on the borderline of coverage percentages. This function is an "LMS import" function, where we're basically hiding the LMS imports that won't work in a testing environment, which, by its nature, won't be covered by test coverage.

This is a decently big block, and hopefully a small change that will save some grief, at least in the long term before this is refactored away on our "LMS Import Object" ticket 