### PR TITLE
fix: add team support link

### DIFF
--- a/openassessment/templates/openassessmentblock/response/oa_response.html
+++ b/openassessment/templates/openassessmentblock/response/oa_response.html
@@ -314,7 +314,7 @@
                       {% trans "One team member should submit on behalf of the entire team."%}
                   {% endif %}
                   {% blocktrans %}
-                  Learn more about team assignments here: (<a href="" >link</a>)
+                  Learn more about team assignments here: (<a target="_blank" href="https://support.edx.org/hc/en-us/articles/360000191067-Submit-your-response#h_01FVD8SXM9E5H2DNAG87X25ZHR">link</a>)
                   {% endblocktrans %}
                 </div>
               {% endif %}


### PR DESCRIPTION
**TL;DR -** add missing link to the anchor tag for team

JIRA: [AU-604](https://openedx.atlassian.net/browse/AU-604)

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- Setup team and follow the instruction of AU-604
- the link should lead you to [team support document](https://support.edx.org/hc/en-us/articles/360000191067-Submit-your-response#h_01FVD8SXM9E5H2DNAG87X25ZHR)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
