### PR TITLE
chore: remove term 'enhanced staff grader' from button

### DIFF
--- a/openassessment/templates/openassessmentblock/staff_area/oa_staff_area.html
+++ b/openassessment/templates/openassessmentblock/staff_area/oa_staff_area.html
@@ -13,7 +13,7 @@
         <button class="ui-staff__button button-staff-info" aria-expanded="false" data-panel="openassessment__staff-info">{% trans "View Assignment Statistics" %}</button>
         {% if staff_assessment_required %}
             {% if is_enhanced_staff_grader_enabled %}
-                <a href="{{enhanced_staff_grader_url}}" class="ui-staff__button button-enhanced-staff-grader" aria-expanded="false">{% trans "Enhanced Staff Grader" %} <span class="icon fa fa-external-link" aria-hidden="true"></span></a>
+                <a href="{{enhanced_staff_grader_url}}" class="ui-staff__button button-enhanced-staff-grader" aria-expanded="false">{% trans "Grade Available Responses" %} <span class="icon fa fa-external-link" aria-hidden="true"></span></a>
             {% else %}
                 <button class="ui-staff__button button-staff-grading" aria-expanded="false" data-panel="openassessment__staff-grading">{% trans "Grade Available Responses" %}</button>
                 {% comment %} Remove if block in AU-617 {% endcomment %}

--- a/openassessment/xblock/static/js/spec/lms/oa_staff_area.js
+++ b/openassessment/xblock/static/js/spec/lms/oa_staff_area.js
@@ -360,7 +360,7 @@ describe('OpenAssessment.StaffAreaView', function() {
                 expect($buttons).toHaveAttr('aria-expanded', 'false');
                 expect($($buttons[0]).text().trim()).toEqual('Manage Individual Learners');
                 expect($($buttons[1]).text().trim()).toEqual('View Assignment Statistics');
-                expect($($buttons[2]).text().trim()).toEqual('Enhanced Staff Grader');
+                expect($($buttons[2]).text().trim()).toEqual('Grade Available Responses');
                 expect($($buttons[3]).text().trim()).toEqual('View ORA in Studio');
             });
             it('when ora staff grader is disabled', function() {


### PR DESCRIPTION
**TL;DR -** [Make the button not say "Enhanced Staff Grader" ]

JIRA: [AU-640]( https://2u-internal.atlassian.net/browse/AU-640)

**What changed?**

- "Enhanced Staff Grader" -> "Grade Available Responses"

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
