### PR TITLE
fix: upgrade pip-tools to fix bug in version 6.6.1

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION
**TL;DR -**

This commit upgrades the version of pip-tools used in this repository from `6.6.0` to `6.6.2`.

In version `6.6.0` of `pip-tools`, there is a bug that is preventing `pip-tools` from working. This is breaking the Python requirements update GitHub action in this repository.

The error is `ImportError: cannot import name 'BAR_TYPES' from 'pip._internal.cli.progress_bars'`. The error was reported [here](https://github.com/jazzband/pip-tools/issues/1617). The fix to this bug was released in version `6.6.2` of `pip-tools`. See the comment [here](https://github.com/jazzband/pip-tools/issues/1617#issuecomment-1126245586).

Version `6.6.1` of `pip-tools` also has a bug, which is fixed in version `6.6.2`. I observed this issue breaking the Python requirements update GitHub action in another repository, so I have upgrade the version straight to `6.6.2`. The issue in version `6.6.1` was reported [here](https://github.com/jazzband/pip-tools/pull/1624).

JIRA: None.

**What changed?**

See above.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

1. Run `make upgrade`.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [x] I've tested the new functionality

FYI: @openedx/content-aurora
