### PR TITLE
fix: don't check if submission_uuid from bulk_fetch_workflow matches

### DIFF
--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -405,7 +405,7 @@ class StaffGraderMixin:
             return {}
 
         assessments = self.bulk_deep_fetch_assessments([workflow.assessment])
-        if len(assessments) != 1 or submission_uuid not in assessments:
+        if len(assessments) != 1:
             log.error(
                 (
                     "[%s] Error looking up assessments. Submission UUID = %s, "
@@ -415,7 +415,7 @@ class StaffGraderMixin:
             )
             raise JsonHandlerError(500, "Error looking up assessments")
 
-        assessment = assessments[submission_uuid]
+        _, assessment = assessments.popitem()
         return AssessmentSerializer(assessment).data
 
     @XBlock.json_handler

--- a/openassessment/staffgrader/tests/test_get_assessment_info.py
+++ b/openassessment/staffgrader/tests/test_get_assessment_info.py
@@ -111,12 +111,6 @@ class GetAssessmentInfoTests(StaffGraderMixinTestBase):
         self.assert_response(response, 200, {})
 
     @scenario('data/simple_self_staff_scenario.xml', user_id='Bob')
-    def test_no_bulk_assessments(self, xblock):
-        """ What happens if `bulk_deep_fetch_assessments` returns no assessments? """
-        submission_uuid = str(uuid4())
-        self._test_bulk_deep_fetch_assessments_errors(xblock, submission_uuid, {})
-
-    @scenario('data/simple_self_staff_scenario.xml', user_id='Bob')
     def test_multiple_bulk_assessments(self, xblock):
         """ What happens if `bulk_deep_fetch_assessments` returns multiple assessments? """
         submission_uuid = str(uuid4())


### PR DESCRIPTION
**TL;DR -** For team submissions, we request assessment details using the team submission uuid. We look up the TeamStaffWorkflow for the team submission uuid, and then get the assessment associated with this workflow. The problem here is that that assessment is for one of the individual submissions, so the submission uuid on the assessment won't be the team submission uuid. 

This is a fix so that grading can happen, but we will need a more robust solution, since the grade not showing up on the listing page is this exact same issue, but without this workaround.

JIRA: [AU-654](https://2u-internal.atlassian.net/browse/AU-654)

**What changed?**

- Removed the check for non-matching submission uuids, since for now this is expected behavior.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- You should be able to grade team oras, override the grade for team ORAs, and view graded team oras locally, once you have short circuted the code that forces team ORAs to use demo mode.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
