### PR TITLE
feat: add logging for unhandled file errors

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -1,4 +1,4 @@
 """
 Initialization Information for Open Assessment Module
 """
-__version__ = '4.4.2'
+__version__ = '4.4.3'

--- a/openassessment/xblock/submission_mixin.py
+++ b/openassessment/xblock/submission_mixin.py
@@ -318,7 +318,13 @@ class SubmissionMixin:
                 exc_info=True,
             )
             return {'success': False, 'msg': self._("Files metadata could not be saved.")}
-
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception(
+                "FileUploadError: unhandled exception for data %s. Error: %s",
+                data,
+                exc,
+                exc_info=True,
+            )
         return {'success': True, 'msg': ''}
 
     def create_team_submission(self, student_sub_data):
@@ -562,6 +568,13 @@ class SubmissionMixin:
                     student_item_key,
                     exc,
                     exc_info=True
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.exception(
+                    "FileUploadError: unhandled exception for data %s. Error: %s",
+                    data,
+                    exc,
+                    exc_info=True,
                 )
 
         return {'success': False}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.2.1",
+  "version": "4.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.2.1",
+  "version": "4.4.3",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** Unhandled errors for file put/delete are not logging anywhere. Add fall-through logging

Logs follow the format:
```
FileUploadError: unhandled exception for data <data>. Exception: <exception>
```
JIRA: Inspired by [AU-656](https://2u-internal.atlassian.net/browse/AU-656)

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/edx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [setup.py](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/edx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora 
