### PR TITLE
Jkantor/peer step zero

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -1,4 +1,4 @@
 """
 Initialization Information for Open Assessment Module
 """
-__version__ = '4.4.4'
+__version__ = '4.4.5'

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -422,7 +422,7 @@ class GradeMixin:
 
         median_scores = peer_api.get_assessment_median_scores(submission_uuid)
         median_score = median_scores.get(criterion['name'], None)
-        median_score = -1 if not median_score else median_score
+        median_score = -1 if median_score is None else median_score
 
         def median_options():
             """

--- a/openassessment/xblock/test/data/feedback_per_criterion.xml
+++ b/openassessment/xblock/test/data/feedback_per_criterion.xml
@@ -24,6 +24,10 @@
                 <name>ק๏๏г</name>
                 <explanation>Wordy</explanation>
             </option>
+            <option points="0">
+                <name>Very Bad</name>
+                <explanation>Horrible</explanation>
+            </option>
         </criterion>
         <criterion feedback="optional">
             <name>Form</name>

--- a/openassessment/xblock/test/test_grade.py
+++ b/openassessment/xblock/test/test_grade.py
@@ -231,9 +231,9 @@ class TestGrade(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         _, context = xblock.render_grade_complete(xblock.get_workflow_info())
         criteria = context['grade_details']['criteria']
         # Verify that the median peer grades are correct
-        self.assertEqual(criteria[0]['assessments'][0]['option']['label'], 'Waiting for peer reviews')
+        self.assertEqual(criteria[0]['assessments'][0]['option']['label'], 'Very Bad')
         self.assertEqual(criteria[1]['assessments'][0]['option']['label'], 'Fair / Good')
-        self.assertNotIn('points', criteria[0]['assessments'][0])
+        self.assertEqual(criteria[0]['assessments'][0]['points'], 0)
         self.assertEqual(criteria[1]['assessments'][0]['points'], 3)
 
     @ddt.data(


### PR DESCRIPTION
**TL;DR -** Use the correct criterion option info when the point value of the median option is 0

JIRA: [AU-577](https://2u-internal.atlassian.net/browse/AU-577)

**Testing Instructions**

(This one's a pain, I don't expect anyone to manually test it. But if you so desire:)

- Make a peer ORA with a rubric with a criterion option for zero points.
- Have a submission be peer graded and recieve a final grade for which one or more criteria recieve the zero point option
- A small text bug can be seen in the "final grade" section and in the "manage individual learner" section (see ticket)
- check out this branch
- The bug should be resolved.

<img width="350" alt="Screen Shot 2022-07-20 at 9 58 10 AM" src="https://user-images.githubusercontent.com/1639231/180000934-7eab2369-b9d5-4559-9077-a0241ee22ee6.png">


**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
