### PR TITLE
chore: bump submissions to 3.5.4

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -1,4 +1,4 @@
 """
 Initialization Information for Open Assessment Module
 """
-__version__ = '4.4.6'
+__version__ = '4.4.7'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.4.6",
+  "version": "4.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.4.6",
+  "version": "4.4.7",
   "repository": "https://github.com/edx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -68,7 +68,7 @@ edx-i18n-tools==0.9.1
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via -r requirements/base.in
-edx-submissions==3.5.3
+edx-submissions==3.5.4
     # via -r requirements/base.in
 edx-toggles==5.0.0
     # via -r requirements/base.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -165,7 +165,7 @@ edx-lint==5.2.4
     # via -r requirements/quality.in
 edx-opaque-keys==2.3.0
     # via -r requirements/test.txt
-edx-submissions==3.5.3
+edx-submissions==3.5.4
     # via -r requirements/test.txt
 edx-toggles==5.0.0
     # via -r requirements/test.txt

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -155,7 +155,7 @@ edx-i18n-tools==0.9.1
     # via -r requirements/test.txt
 edx-opaque-keys==2.3.0
     # via -r requirements/test.txt
-edx-submissions==3.5.3
+edx-submissions==3.5.4
     # via -r requirements/test.txt
 edx-toggles==5.0.0
     # via -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -131,7 +131,7 @@ edx-i18n-tools==0.9.1
     # via -r requirements/base.txt
 edx-opaque-keys==2.3.0
     # via -r requirements/base.txt
-edx-submissions==3.5.3
+edx-submissions==3.5.4
     # via -r requirements/base.txt
 edx-toggles==5.0.0
     # via -r requirements/base.txt


### PR DESCRIPTION
I released a version of submissions and missed a migration, and you seemingly can't just re-release something on pypi. So, round 2