### PR TITLE
fix: Add tx in the path for transifex commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ detect_changed_source_translations: ## check if translation files are up-to-date
 	i18n_tool changed
 
 pull_translations: ## pull translations from Transifex
-	cd ./openassessment/ && ../tx pull -a -f --mode reviewed --minimum-perc=1
+	cd ./openassessment/ && tx pull -a -f --mode reviewed --minimum-perc=1
 
 push_translations: ## push source translation files (.po) to Transifex
 	tx push -s
@@ -151,5 +151,7 @@ install_transifex_client: ## Install the Transifex client
 	# so remind the user to commit the change first before installing client.
 	git diff -s --exit-code HEAD || { echo "Please commit changes first."; exit 1; }
 	curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+	# Load the PATH changes to make transifex client accessible from any directory i.e. openassessment for pull translations
+	export PATH="$(PATH):$(pwd)"
 	git checkout -- LICENSE ## overwritten by Transifex installer
 	rm README.md ## pulled by Transifex installer


### PR DESCRIPTION
### Description
- https://github.com/openedx/edx-ora2/pull/1889 added new Make command to install transifex client locally.
- To run the client locally, the path for the `tx` in `make pull_translations` command was updated.
- Updating the path caused the scheduled `pull_translations` job to fail on `Jenkins`.
- Reverted the `pull_translations` command update and instead added the new client in the PATH to make it accessible everywhere in the directory.