### PR TITLE
fix: update transifex flag for tx cli 1.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ detect_changed_source_translations: ## check if translation files are up-to-date
 	i18n_tool changed
 
 pull_translations: ## pull translations from Transifex
-	tx pull -a -f --mode reviewed --minimum-perc=1
+	tx pull -a -f -t --mode reviewed --minimum-perc=1
 
 push_translations: ## push source translation files (.po) to Transifex
 	tx push -s


### PR DESCRIPTION
The Transifex cli started requiring the -t or --translations flag in the pull command in order to fetch translations.

https://github.com/transifex/cli/pull/96