### PR TITLE
fix: Added region and signature for S3 bucket

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -1,4 +1,4 @@
 """
 Initialization Information for Open Assessment Module
 """
-__version__ = '5.1.0'
+__version__ = '5.1.1'

--- a/openassessment/fileupload/backends/s3.py
+++ b/openassessment/fileupload/backends/s3.py
@@ -75,12 +75,18 @@ def _connect_to_s3():
     aws_access_key_id = getattr(settings, "AWS_ACCESS_KEY_ID", None)
     aws_secret_access_key = getattr(settings, "AWS_SECRET_ACCESS_KEY", None)
     endpoint_url = getattr(settings, "AWS_S3_ENDPOINT_URL", None)
+    signature_version = getattr(settings, "AWS_S3_SIGNATURE_VERSION", None)
+    region_name = getattr(settings, "AWS_S3_REGION_NAME", None)
 
     return boto3.client(
         "s3",
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         endpoint_url=endpoint_url,
+        config=botocore.client.Config(
+            signature_version=signature_version,
+            region_name=region_name,
+        )
     )
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
For a region based bucket boto3 needs to know about region and signature which edx-ora2 doesn't know about.

**TL;DR -** Currently edx-ora2 doesn't pick up AWS region or aws signature version and because of that boto3 generates a faulty S3 URL. The [boto3 documentation for s3 signature v4](https://boto3.amazonaws.com/v1/documentation/api/1.9.42/guide/s3.html#generating-presigned-urls) also shows the boto3 client need to know the signature version.

JIRA: None

**What changed?**

- Config to add AWS configuration for S3

When I was trying to upload the file in S3 bucket in the me-south-1 region, I kept on getting 
![image](https://user-images.githubusercontent.com/7670449/228396499-fc1d8c42-9c59-4d10-879c-064735656a8d.png)

The reason was boto3 client doesn't use S3_SIGNATURE=`s3v4` and region value here in edx-ora2 while the same config was working properly on discussions.


**Developer Checklist**

- ✅ Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- ❌  Translations and JS/SASS compiled
- ❌  Bumped version number in [setup.py](https://github.com/openedx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/openedx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- None since it just adds configs

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality
