### PR TITLE
style: remove lint-amnesty for dict literals

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -1,4 +1,4 @@
 """
 Initialization Information for Open Assessment Module
 """
-__version__ = '5.0.0'
+__version__ = '5.0.1'

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -25,12 +25,12 @@ from openassessment.workflow.models import AssessmentWorkflow
 from openassessment.test_utils import CacheResetTest
 from openassessment.workflow import api as workflow_api
 
-STUDENT_ITEM = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id="Tim",
-    course_id="Demo_Course",
-    item_id="item_one",
-    item_type="Peer_Submission",
-)
+STUDENT_ITEM = {
+    "student_id": "Tim",
+    "course_id": "Demo_Course",
+    "item_id": "item_one",
+    "item_type": "Peer_Submission",
+}
 
 ANSWER_ONE = "this is my answer!"
 

--- a/openassessment/assessment/views.py
+++ b/openassessment/assessment/views.py
@@ -32,12 +32,12 @@ def get_evaluations_for_student_item(request, course_id, student_id, item_id):  
             student item.
 
     """
-    student_item_dict = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-        course_id=course_id,
-        student_id=student_id,
-        item_id=item_id,
-    )
-    context = dict(**student_item_dict)  # lint-amnesty, pylint: disable=use-dict-literal
+    student_item_dict = {
+        "course_id": course_id,
+        "student_id": student_id,
+        "item_id": item_id,
+    }
+    context = {**student_item_dict}
     try:
         submissions = get_submissions(student_item_dict)
         evaluations = []

--- a/openassessment/staffgrader/tests/test_get_submission_info.py
+++ b/openassessment/staffgrader/tests/test_get_submission_info.py
@@ -78,12 +78,12 @@ class GetSubmissionInfoTests(StaffGraderMixinTestBase):
             "This is my response for <a href='www.edx.org'>Prompt Three</a>"
         ]
         file_responses = [
-            dict(  # lint-amnesty, pylint: disable=use-dict-literal
-                download_url='A', description='B', name='C', size=100
-            ),
-            dict(  # lint-amnesty, pylint: disable=use-dict-literal
-                download_url='1', description='2', name='3', size=300
-            ),
+            {
+                "download_url": 'A', "description": 'B', "name": 'C', "size": 100
+            },
+            {
+                "download_url": '1', "description": '2', "name": '3', "size": 300
+            },
         ]
 
         submission_uuid = str(uuid4())

--- a/openassessment/staffgrader/tests/test_list_staff_workflows.py
+++ b/openassessment/staffgrader/tests/test_list_staff_workflows.py
@@ -35,13 +35,15 @@ EXPECTED_ANNOTATED_WORKFLOW_FIELDS = [
     'assessment',
     'scorer_id'
 ]
-STUDENT_ITEM = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id="",
-    course_id="course-v1:testCourse+t5+2021T2",
-    item_id="TestStaffWorkflowListView",
-    item_type="openassessment",
-)
-ANSWER = dict(parts=['test_answer'])  # lint-amnesty, pylint: disable=use-dict-literal
+STUDENT_ITEM ={
+    "student_id": "",
+    "course_id": "course-v1:testCourse+t5+2021T2",
+    "item_id": "TestStaffWorkflowListView",
+    "item_type": "openassessment",
+}
+ANSWER = {
+    "parts": ['test_answer']
+}
 STAFF_ID = "TestStaffUser"
 SUBMITTED_DATE = datetime(2020, 3, 2, 12, 35, tzinfo=timezone.utc)
 TEST_START_DATE = SUBMITTED_DATE + timedelta(days=2)

--- a/openassessment/staffgrader/tests/test_list_staff_workflows.py
+++ b/openassessment/staffgrader/tests/test_list_staff_workflows.py
@@ -35,7 +35,7 @@ EXPECTED_ANNOTATED_WORKFLOW_FIELDS = [
     'assessment',
     'scorer_id'
 ]
-STUDENT_ITEM ={
+STUDENT_ITEM = {
     "student_id": "",
     "course_id": "course-v1:testCourse+t5+2021T2",
     "item_id": "TestStaffWorkflowListView",

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -74,33 +74,33 @@ ITEM_PATH_INFO = {
     "ora_name": ITEM_DISPLAY_NAME,
 }
 
-STUDENT_ITEM = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id=STUDENT_ID,
-    course_id=COURSE_ID,
-    item_id=ITEM_ID,
-    item_type="openassessment"
-)
+STUDENT_ITEM = {
+    "student_id": STUDENT_ID,
+    "course_id": COURSE_ID,
+    "item_id": ITEM_ID,
+    "item_type": "openassessment"
+}
 
-PRE_FILE_SIZE_STUDENT_ITEM = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id=PRE_FILE_SIZE_STUDENT_ID,
-    course_id=COURSE_ID,
-    item_id=ITEM_ID,
-    item_type="openassessment"
-)
+PRE_FILE_SIZE_STUDENT_ITEM = {
+    "student_id": PRE_FILE_SIZE_STUDENT_ID,
+    "course_id": COURSE_ID,
+    "item_id": ITEM_ID,
+    "item_type": "openassessment"
+}
 
-PRE_FILE_NAME_STUDENT_ITEM = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id=PRE_FILE_NAME_STUDENT_ID,
-    course_id=COURSE_ID,
-    item_id=ITEM_ID,
-    item_type="openassessment"
-)
+PRE_FILE_NAME_STUDENT_ITEM = {
+    "student_id": PRE_FILE_NAME_STUDENT_ID,
+    "course_id": COURSE_ID,
+    "item_id": ITEM_ID,
+    "item_type": "openassessment"
+}
 
-SCORER_ITEM = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id=SCORER_ID,
-    course_id=COURSE_ID,
-    item_id=ITEM_ID,
-    item_type="openassessment"
-)
+SCORER_ITEM = {
+    "student_id": SCORER_ID,
+    "course_id": COURSE_ID,
+    "item_id": ITEM_ID,
+    "item_type": "openassessment"
+}
 
 ITEM_DISPLAY_NAMES_MAPPING = {
     SCORER_ITEM['item_id']: ITEM_DISPLAY_NAME,
@@ -327,11 +327,11 @@ class TestOraAggregateData(TransactionCacheResetTest):
                 criterion_options.append(CriterionOptionFactory(criterion=criterion))
 
         assessment_options = assessment_options or {'scorer_id': TEST_SCORER_ID}
-        assessment_data = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-            rubric=rubric,
-            feedback=feedback,
+        assessment_data = {
+            "rubric": rubric,
+            "feedback": feedback,
             **assessment_options
-        )
+        }
         assessment = AssessmentFactory(**assessment_data)
         for criterion, option in zip(criteria, criterion_options):
             AssessmentPartFactory(assessment=assessment, criterion=criterion, option=option, feedback=feedback)
@@ -382,22 +382,22 @@ class TestOraAggregateData(TransactionCacheResetTest):
     def test_map_students_and_scorers_ids_to_usernames(self):
         test_submission_information = [
             (
-                dict(  # lint-amnesty, pylint: disable=use-dict-literal
-                    student_id=STUDENT_ID,
-                    course_id=COURSE_ID,
-                    item_id="some_id",
-                    item_type="openassessment",
-                ),
+                {
+                    "student_id": STUDENT_ID,
+                    "course_id": COURSE_ID,
+                    "item_id": "some_id",
+                    "item_type": "openassessment",
+                },
                 sub_api.create_submission(STUDENT_ITEM, ANSWER),
                 (),
             ),
             (
-                dict(  # lint-amnesty, pylint: disable=use-dict-literal
-                    student_id=SCORER_ID,
-                    course_id=COURSE_ID,
-                    item_id="some_id",
-                    item_type="openassessment",
-                ),
+                {
+                    "student_id": SCORER_ID,
+                    "course_id": COURSE_ID,
+                    "item_id": "some_id",
+                    "item_type": "openassessment",
+                },
                 sub_api.create_submission(SCORER_ITEM, ANSWER),
                 (),
             ),
@@ -881,37 +881,37 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
         student_model_1 = UserFactory.create()
         student_model_2 = UserFactory.create()
 
-        self._create_submission(dict(  # lint-amnesty, pylint: disable=use-dict-literal
-            student_id=STUDENT_ID,
-            course_id=COURSE_ID,
-            item_id=item_id2,
-            item_type="openassessment"
-        ), ['self'])
-        self._create_submission(dict(  # lint-amnesty, pylint: disable=use-dict-literal
-            student_id=student_id2,
-            course_id=COURSE_ID,
-            item_id=item_id2,
-            item_type="openassessment"
-        ), STEPS)
+        self._create_submission({
+            "student_id": STUDENT_ID,
+            "course_id": COURSE_ID,
+            "item_id": item_id2,
+            "item_type": "openassessment"
+        }, ['self'])
+        self._create_submission({
+            "student_id": student_id2,
+            "course_id": COURSE_ID,
+            "item_id": item_id2,
+            "item_type": "openassessment"
+        }, STEPS)
 
-        self._create_submission(dict(  # lint-amnesty, pylint: disable=use-dict-literal
-            student_id=STUDENT_ID,
-            course_id=COURSE_ID,
-            item_id=item_id3,
-            item_type="openassessment"
-        ), ['self'])
-        self._create_submission(dict(  # lint-amnesty, pylint: disable=use-dict-literal
-            student_id=student_id2,
-            course_id=COURSE_ID,
-            item_id=item_id3,
-            item_type="openassessment"
-        ), ['self'])
-        self._create_submission(dict(  # lint-amnesty, pylint: disable=use-dict-literal
-            student_id=student_id3,
-            course_id=COURSE_ID,
-            item_id=item_id3,
-            item_type="openassessment"
-        ), STEPS)
+        self._create_submission({
+            "student_id": STUDENT_ID,
+            "course_id": COURSE_ID,
+            "item_id": item_id3,
+            "item_type": "openassessment"
+        }, ['self'])
+        self._create_submission({
+            "student_id": student_id2,
+            "course_id": COURSE_ID,
+            "item_id": item_id3,
+            "item_type": "openassessment"
+        }, ['self'])
+        self._create_submission({
+            "student_id": student_id3,
+            "course_id": COURSE_ID,
+            "item_id": item_id3,
+            "item_type": "openassessment"
+        }, STEPS)
 
         self._create_team_submission(
             COURSE_ID,

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -492,12 +492,12 @@ class OpenAssessmentBlock(MessageMixin,
             else:
                 student_id = str(self.scope_ids.user_id)
 
-        student_item_dict = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-            student_id=student_id,
-            item_id=item_id,
-            course_id=course_id,
-            item_type='openassessment'
-        )
+        student_item_dict = {
+            "student_id": student_id,
+            "item_id": item_id,
+            "course_id": course_id,
+            "item_type": 'openassessment'
+        }
         return student_item_dict
 
     def add_javascript_files(self, fragment, item):

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -39,19 +39,19 @@ FILE_URL = 'www.fileurl.com'
 SAVED_FILES_DESCRIPTIONS = ['file1', 'file2']
 SAVED_FILES_NAMES = ['file1.txt', 'file2.txt']
 
-STUDENT_ITEM = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id="Bob",
-    course_id="test_course",
-    item_id="item_one",
-    item_type="openassessment",
-)
+STUDENT_ITEM = {
+    "student_id": "Bob",
+    "course_id": "test_course",
+    "item_id": "item_one",
+    "item_type": "openassessment",
+}
 
-TEAMMATE_ITEM = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id=MOCK_TEAM_MEMBER_STUDENT_IDS[0],
-    course_id="test_course",
-    item_id="item_one",
-    item_type="openassessment",
-)
+TEAMMATE_ITEM = {
+    "student_id": MOCK_TEAM_MEMBER_STUDENT_IDS[0],
+    "course_id": "test_course",
+    "item_id": "item_one",
+    "item_type": "openassessment",
+}
 
 ASSESSMENT_DICT = {
     'overall_feedback': "这是中国",

--- a/openassessment/xblock/test/test_team_workflow_mixin.py
+++ b/openassessment/xblock/test/test_team_workflow_mixin.py
@@ -10,12 +10,12 @@ from submissions.errors import TeamSubmissionNotFoundError
 from openassessment.xblock.team_workflow_mixin import TeamWorkflowMixin
 
 
-STUDENT_ITEM_DICT = dict(  # lint-amnesty, pylint: disable=use-dict-literal
-    student_id='student_id_1',
-    item_id='item1',
-    course_id='course1',
-    item_type='openassessment'
-)
+STUDENT_ITEM_DICT = {
+    "student_id": 'student_id_1',
+    "item_id": 'item1',
+    "course_id": 'course1',
+    "item_type": 'openassessment'
+}
 
 SUBMISSION_UUID = 'submission 1'
 TEAM_SUB_ID_1 = 'team_submission 1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.5.1",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "4.5.1",
+  "version": "5.0.1",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** [ A short summary of what this PR does and why ]

JIRA: [AU-1064](https://2u-internal.atlassian.net/browse/AU-1064)

**What changed?**

- Remove old `lint-amnesty` for `dict-literal` updating to `{}` style.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Bumped version number in [setup.py](https://github.com/openedx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/openedx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)

**Testing Instructions**

- Unit tests only, no behavior modified.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
