### PR TITLE
refactor: use `days_early_for_beta` from `InheritanceMixin` instead of runtime [FC-0026]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ JIRA: [JIRA-XXXX](https://openedx.atlassian.net/browse/JIRA-XXXX)
 
 - [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
 - [ ] Translations and JS/SASS compiled
-- [ ] Bumped version number in [setup.py](https://github.com/openedx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/setup.py#L39) and [package.json](https://github.com/openedx/edx-ora2/blob/a62e81a9b0d89223476967ec3c27f3557a850735/package.json#L3)
+- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)
 
 **Testing Instructions**
 

--- a/.github/release_process.md
+++ b/.github/release_process.md
@@ -7,14 +7,14 @@ Before Merging a pull request:
 - [ ] Get a green Travis build for this PR
 - [ ] Address PR comments
 - [ ] Get approving review from code owner
-- [ ] Bump version number in [setup.py](../setup.py) and [package.json](../package.json) following [semantic versioning](https://semver.org/) conventions
+- [ ] Bump version number in [openassessment/\_\_init\_\_.py](../openassessment/__init__.py) and [package.json](../package.json) following [semantic versioning](https://semver.org/) conventions
 
 ## Publish to PyPi
 
 When a PR is ready to release, do the following to publish a new version of ORA:
 
 - [ ] Merge to `master`
-- [ ] Create a [release tag on GitHub](https://github.com/openedx/edx-ora2/releases) matching version number in setup.py/package.json
+- [ ] Create a [release tag on GitHub](https://github.com/openedx/edx-ora2/releases) matching version number in `openassessment/__init__.py`/`package.json`
 - [ ] Grab a coffee while our automated process submits the build to PyPi
 - [ ] Confirm new version appears in [PyPi: ora2](https://pypi.org/project/ora2)
 

--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -1,4 +1,4 @@
 """
 Initialization Information for Open Assessment Module
 """
-__version__ = '5.0.2'
+__version__ = '5.0.3'

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -1339,12 +1339,10 @@ class OpenAssessmentBlock(MessageMixin,
         """
         Returns the start date for a Beta tester.
         """
-        if hasattr(self, "xmodule_runtime"):
-            days_early_for_beta = getattr(self.xmodule_runtime, 'days_early_for_beta', 0)  # pylint: disable=no-member
-            if days_early_for_beta is not None:
-                delta = dt.timedelta(days_early_for_beta)
-                effective = start - delta
-                return effective
+        if days_early_for_beta := getattr(self, 'days_early_for_beta', None):
+            delta = dt.timedelta(days_early_for_beta)
+            effective = start - delta
+            return effective
 
         return start
 

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -313,10 +313,10 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         """
         Helper function to set up start date early for beta testers
         """
+        xblock.days_early_for_beta = days_early
         xblock.xmodule_runtime = Mock(
             course_id='test_course',
             anonymous_student_id='test_student',
-            days_early_for_beta=days_early,
             user_is_staff=False,
             user_is_beta_tester=True
         )
@@ -375,7 +375,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             # Set start dates
             xblock = self._set_up_start_date(dt.datetime(2014, 4, 6, 1, 1, 1))
             self._set_up_days_early_for_beta(xblock, 5)
-            self.assertEqual(xblock.xmodule_runtime.days_early_for_beta, 5)
+            self.assertEqual(xblock.days_early_for_beta, 5)
 
             resp = self._render_xblock(xblock)
             self.assertIn(expected_start_date, resp.body.decode('utf-8'))
@@ -392,7 +392,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             xblock = self._set_up_start_date(dt.datetime(2014, 4, 6, 1, 1, 1))
             xblock.due = dt.datetime(2014, 5, 1)
             self._set_up_days_early_for_beta(xblock, 5)
-            self.assertEqual(xblock.xmodule_runtime.days_early_for_beta, 5)
+            self.assertEqual(xblock.days_early_for_beta, 5)
             resp = self._render_xblock(xblock)
             self.assertIn(expected_end_date, resp.body.decode('utf-8'))
 
@@ -449,7 +449,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             # Set start dates
             xblock = self._set_up_start_date(dt.datetime(2014, 4, 6, 1, 1, 1))
             self._set_up_days_early_for_beta(xblock, None)
-            self.assertEqual(xblock.xmodule_runtime.days_early_for_beta, None)
+            self.assertEqual(xblock.days_early_for_beta, None)
 
             resp = self._render_xblock(xblock)
             self.assertIn(expected_start_date, resp.body.decode('utf-8'))
@@ -465,7 +465,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             # Set due dates
             xblock = self._set_up_end_date(dt.datetime(2014, 5, 1))
             self._set_up_days_early_for_beta(xblock, None)
-            self.assertEqual(xblock.xmodule_runtime.days_early_for_beta, None)
+            self.assertEqual(xblock.days_early_for_beta, None)
 
             resp = self._render_xblock(xblock)
             self.assertIn(expected_end_date, resp.body.decode('utf-8'))

--- a/openassessment/xblock/test/test_staff.py
+++ b/openassessment/xblock/test/test_staff.py
@@ -443,7 +443,6 @@ class TestStaffTeamAssessment(StaffAssessmentTestBase):
             is_admin,
             anonymous_user_id,
             user_is_beta=False,
-            days_early_for_beta=0
     ):
         """
         Internal helper to define a mock runtime.
@@ -455,7 +454,6 @@ class TestStaffTeamAssessment(StaffAssessmentTestBase):
             user_is_staff=is_staff,
             user_is_admin=is_admin,
             user_is_beta=user_is_beta,
-            days_early_for_beta=days_early_for_beta,
             service=lambda self, service: Mock(
                 get_anonymous_student_id=lambda user_id, course_id: anonymous_user_id
             )

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -1440,7 +1440,6 @@ class TestCourseStaff(XBlockHandlerTestCase):
             is_admin,
             anonymous_user_id,
             user_is_beta=False,
-            days_early_for_beta=0
     ):
         """
         Internal helper to define a mock runtime.
@@ -1452,7 +1451,6 @@ class TestCourseStaff(XBlockHandlerTestCase):
             user_is_staff=is_staff,
             user_is_admin=is_admin,
             user_is_beta=user_is_beta,
-            days_early_for_beta=days_early_for_beta,
             service=lambda self, service: Mock(
                 get_anonymous_student_id=lambda user_id, course_id: anonymous_user_id
             )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** Use the block's property directly instead of getting it from the runtime.

**What changed?**

FC-0026 removes the block-specific handling from the runtime. In https://github.com/openedx/edx-platform/pull/32356, we are simplifying user checks. `prepare_runtime_for_user` adds the `days_early_for_beta` attribute to the runtime, but this value is already provided by the `InheritanceMixin`. We are removing this redundancy, so this makes `ora2` retrieve the value directly from XBlock fields.

This also updates the PR template and the release process doc, as they were slightly outdated.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled: n/a
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

1. Go to the [Course Advanced Settings](http://localhost:18010/settings/advanced/course-v1:edX+DemoX+Demo_Course) and set `Days Early for Beta Users` to `6000`.
2. Create an ORA2 XBlock. Go to `Edit -> SCHEDULE` and set its start dates to `2030`.
3. Go to the [Instructor Dashboard -> Membership](http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-membership) and enroll `audit` as a beta tester.
4. Visit LMS as the `audit` user and check that you can submit the solution.

#### Supporting information

Private-ref: [BB-7448](https://tasks.opencraft.com/browse/BB-7448)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
