### PR TITLE
fix: fix hot reload serving of static resources

### DIFF
--- a/openassessment/xblock/load_static.py
+++ b/openassessment/xblock/load_static.py
@@ -6,6 +6,7 @@ import logging
 
 from pkg_resources import resource_string
 from django.conf import settings
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -36,6 +37,8 @@ class LoadStatic:
         Reload from manifest file
         """
         root_url, base_url = '', '/static/dist/'
+        base_url_override = ''
+
         if hasattr(settings, 'LMS_ROOT_URL'):
             root_url = settings.LMS_ROOT_URL
         else:
@@ -44,11 +47,15 @@ class LoadStatic:
         try:
             json_data = resource_string(__name__, 'static/dist/manifest.json').decode("utf8")
             LoadStatic._manifest = json.loads(json_data)
+            base_url_override = LoadStatic._manifest.get('base_url', None)
             LoadStatic._is_loaded = True
         except OSError:
             logger.error('Cannot find static/dist/manifest.json')
         finally:
-            LoadStatic._base_url = urljoin(root_url, base_url)
+            if base_url_override and urlparse(base_url_override).scheme:
+                LoadStatic._base_url = base_url_override
+            else:
+                LoadStatic._base_url = urljoin(root_url, base_url)
 
     @staticmethod
     def get_url(key):


### PR DESCRIPTION
**TL;DR -** Fixes an issue where we weren't actually using an overridden dev server path in our local development workflows.

JIRA: [JIRA-XXXX](https://openedx.atlassian.net/browse/JIRA-XXXX)

**What changed?**

- Edited loading of static scripts to be aware of base URL overrides.
- Edited logic to correctly handle if loaded script is a root URL or a relative URL.

**Developer Checklist**

- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

- Follow developers guide to get a local install of ORA running, up to and including the *Hot Reload Frontend Changes* section.
- Verify that changes to JS are getting loaded and live reloaded correctly.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
