### PR TITLE
fix: forming Response Files link in the report

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -578,16 +578,12 @@ class OraAggregateData:
             string that contains newline-separated URLs to each of the files uploaded for this submission.
         """
         file_links = ''
-        sep = "\n"
         base_url = getattr(settings, 'LMS_ROOT_URL', '')
 
         from openassessment.xblock.openassessmentblock import OpenAssessmentBlock
         file_downloads = OpenAssessmentBlock.get_download_urls_from_submission(submission)
-        for url, _description, _filename, _size, _show_delete in file_downloads:
-            if file_links:
-                file_links += sep
-            file_links += urljoin(base_url, url)
-        return file_links
+        file_links = [urljoin(base_url, file_download.get('download_url')) for file_download in file_downloads]
+        return "\n".join(file_links)
 
     @classmethod
     def collect_ora2_data(cls, course_id):

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -15,7 +15,7 @@ import ddt
 from freezegun import freeze_time
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from submissions import api as sub_api, team_api as team_sub_api
 import openassessment.assessment.api.peer as peer_api
@@ -531,6 +531,26 @@ class TestOraAggregateData(TransactionCacheResetTest):
         feedback_cell = OraAggregateData._build_feedback_cell(assessment2.submission_uuid)
 
         self.assertEqual(feedback_cell, "")
+
+    @override_settings(LMS_ROOT_URL="https://example.com")
+    @patch('openassessment.xblock.openassessmentblock.OpenAssessmentBlock.get_download_urls_from_submission')
+    def test_build_response_file_links(self, mock_method):
+        """
+        Test _build_response_file_links method.
+
+        Ensures that the method returns the expected file links based on the given submission.
+        """
+        expected_result = "https://example.com/file1.pdf\nhttps://example.com/file2.png\nhttps://example.com/file3.jpeg"
+        file_downloads = [
+            {'download_url': '/file1.pdf'},
+            {'download_url': '/file2.png'},
+            {'download_url': '/file3.jpeg'},
+        ]
+        mock_method.return_value = file_downloads
+        # pylint: disable=protected-access
+        result = OraAggregateData._build_response_file_links('test submission')
+
+        self.assertEqual(result, expected_result)
 
 
 @ddt.ddt


### PR DESCRIPTION
**TL;DR -** This is a fix forming "Response Files" link in the reports (in the context of the ORA functionality).

**What changed?**
The link in the formed report doesn't allow checking the uploaded file in the installation server for Instructor:

![image-12](https://github.com/openedx/edx-ora2/assets/98233552/dd9e1e57-a56f-4efa-a3c1-6acec83a6c98)

<img width="1205" alt="image-9" src="https://github.com/openedx/edx-ora2/assets/98233552/0637ce58-f498-42c4-b1e6-702e9d14183c">

![image-10](https://github.com/openedx/edx-ora2/assets/98233552/6b5dbc8f-5169-4180-be07-139c2c22d4fe)

Correspond link allows to download file for instructor:

<img width="1633" alt="image-11" src="https://github.com/openedx/edx-ora2/assets/98233552/40c9702a-4d98-4ece-bc88-3100099b3aff">

I rechecked S3 storage forming link too. It works correctly.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
