### PR TITLE
Jkantor/flexible override

### DIFF
--- a/openassessment/assessment/api/self.py
+++ b/openassessment/assessment/api/self.py
@@ -37,7 +37,7 @@ def submitter_is_finished(submission_uuid, self_requirements):  # pylint: disabl
     ).exists()
 
 
-def assessment_is_finished(submission_uuid, self_requirements):
+def assessment_is_finished(submission_uuid, self_requirements, _):
     """
     Check whether a self-assessment has been completed. For self-assessment,
     this function is synonymous with submitter_is_finished.
@@ -56,13 +56,14 @@ def assessment_is_finished(submission_uuid, self_requirements):
     return submitter_is_finished(submission_uuid, self_requirements)
 
 
-def get_score(submission_uuid, self_requirements):  # pylint: disable=unused-argument
+def get_score(submission_uuid, self_requirements, course_settings):  # pylint: disable=unused-argument
     """
     Get the score for this particular assessment.
 
     Args:
         submission_uuid (str): The unique identifier for the submission
         self_requirements (dict): Not used.
+        course_settings (dict): Not used.
     Returns:
         A dictionary with the points earned, points possible, and
         contributing_assessments information, along with a None staff_id.

--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -35,7 +35,7 @@ def submitter_is_finished(submission_uuid, staff_requirements):  # pylint: disab
     return True
 
 
-def assessment_is_finished(submission_uuid, staff_requirements):
+def assessment_is_finished(submission_uuid, staff_requirements, _):
     """
     Determine if the staff assessment step of the given submission is completed.
     This checks to see if staff have completed the assessment.
@@ -127,7 +127,7 @@ def on_cancel(submission_uuid):
         raise StaffAssessmentInternalError(error_message) from ex
 
 
-def get_score(submission_uuid, staff_requirements):  # pylint: disable=unused-argument
+def get_score(submission_uuid, staff_requirements, course_settings):  # pylint: disable=unused-argument
     """
     Generate a score based on a completed assessment for the given submission.
     If no assessment has been completed for this submission, this will return
@@ -136,6 +136,7 @@ def get_score(submission_uuid, staff_requirements):  # pylint: disable=unused-ar
     Args:
         submission_uuid (str): The UUID for the submission to get a score for.
         staff_requirements (dict): Not used.
+        course_settings (dict): Not used.
 
     Returns:
         A dictionary with the points earned, points possible,

--- a/openassessment/assessment/api/teams.py
+++ b/openassessment/assessment/api/teams.py
@@ -35,7 +35,7 @@ def submitter_is_finished(team_submission_uuid, team_requirements):  # pylint: d
     return True
 
 
-def assessment_is_finished(team_submission_uuid, staff_requirements):
+def assessment_is_finished(team_submission_uuid, staff_requirements, _):
     """
     Determine if the staff assessment step of the given team submission is completed.
     This checks to see if staff have completed the assessment.
@@ -126,7 +126,7 @@ def on_cancel(team_submission_uuid):
         raise StaffAssessmentInternalError(error_message) from ex
 
 
-def get_score(team_submission_uuid, staff_requirements):  # pylint: disable=unused-argument
+def get_score(team_submission_uuid, staff_requirements, course_settings):  # pylint: disable=unused-argument
     """
     Generate a score based on a completed assessment for the given team submission.
     If no assessment has been completed for this submission, this will return
@@ -135,6 +135,7 @@ def get_score(team_submission_uuid, staff_requirements):  # pylint: disable=unus
     Args:
         team_submission_uuid (str): The UUID for the submission to get a score for.
         staff_requirements (dict): Not used.
+        course_settings (dict): Not used.
 
     Returns:
         A dictionary with the points earned, points possible,

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -1880,7 +1880,12 @@ class TestPeerApi(CacheResetTest):
             RUBRIC_DICT,
             step_requirements['peer']['must_be_graded_by']
         )
-        self._assert_assessment_workflow_status(target_learner_sub['uuid'], 'waiting', step_requirements, COURSE_SETTINGS)
+        self._assert_assessment_workflow_status(
+            target_learner_sub['uuid'],
+            'waiting',
+            step_requirements,
+            COURSE_SETTINGS
+        )
 
         # Call get_submission_to_assess once more so that target_learner has an open incomplete peer assessment
         peer_api.get_submission_to_assess(target_learner_sub['uuid'], target_learner['student_id'])
@@ -1905,7 +1910,12 @@ class TestPeerApi(CacheResetTest):
         )
 
         # The target learner is still in waiting and has five items but only one peer grade
-        self._assert_assessment_workflow_status(target_learner_sub['uuid'], 'waiting', step_requirements, COURSE_SETTINGS)
+        self._assert_assessment_workflow_status(
+            target_learner_sub['uuid'],
+            'waiting',
+            step_requirements,
+            COURSE_SETTINGS
+        )
         self.assertEqual(PeerWorkflow.get_by_submission_uuid(target_learner_sub['uuid']).graded_by.count(), 5)
         self.assertEqual(peer_api.get_graded_by_count(target_learner_sub['uuid']), 1)
 

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -159,6 +159,12 @@ STEP_REQUIREMENTS = {
     }
 }
 
+COURSE_SETTINGS = {}
+
+COURSE_SETTINGS_FLEXIBLE_ON = {
+    'force_on_flexible_peer_openassessments': True
+}
+
 
 @ddt
 class TestPeerApi(CacheResetTest):
@@ -262,7 +268,11 @@ class TestPeerApi(CacheResetTest):
         # call get_score for all three to mark items as 'scored'. Everyone shoulfd have a score because
         # they have at least one peer review and have done at least one review.
         for submission, _ in submission_and_learner:
-            peer_score = peer_api.get_score(submission['uuid'], {'must_be_graded_by': 1, 'must_grade': 1})
+            peer_score = peer_api.get_score(
+                submission['uuid'],
+                {'must_be_graded_by': 1, 'must_grade': 1},
+                COURSE_SETTINGS
+            )
             assert peer_score is not None
 
         # There should be three "scored" assessments
@@ -527,7 +537,9 @@ class TestPeerApi(CacheResetTest):
             }
         }
         score = workflow_api.get_workflow_for_submission(
-            tim_sub["uuid"], requirements
+            tim_sub["uuid"],
+            requirements,
+            COURSE_SETTINGS,
         )["score"]
         self.assertIsNone(score)
 
@@ -611,7 +623,9 @@ class TestPeerApi(CacheResetTest):
             }
         }
         score = workflow_api.get_workflow_for_submission(
-            tim_sub["uuid"], requirements
+            tim_sub["uuid"],
+            requirements,
+            COURSE_SETTINGS,
         )["score"]
         self.assertIsNone(score)
 
@@ -638,7 +652,9 @@ class TestPeerApi(CacheResetTest):
 
         # Tim should have no score.
         score = workflow_api.get_workflow_for_submission(
-            tim_sub["uuid"], requirements
+            tim_sub["uuid"],
+            requirements,
+            COURSE_SETTINGS,
         )["score"]
         self.assertIsNone(score)
 
@@ -665,7 +681,9 @@ class TestPeerApi(CacheResetTest):
 
         # Tim should not have a score since he did not grade peers..
         score = workflow_api.get_workflow_for_submission(
-            tim_sub["uuid"], requirements
+            tim_sub["uuid"],
+            requirements,
+            COURSE_SETTINGS,
         )["score"]
         self.assertIsNone(score)
 
@@ -970,8 +988,11 @@ class TestPeerApi(CacheResetTest):
         # Cancel the Xander's submission.
         PeerWorkflow.get_by_submission_uuid(xander_answer['uuid'])
         workflow_api.cancel_workflow(
-            submission_uuid=xander_answer["uuid"], comments='Cancellation reason', cancelled_by_id=_['student_id'],
-            assessment_requirements=STEP_REQUIREMENTS
+            submission_uuid=xander_answer["uuid"],
+            comments='Cancellation reason',
+            cancelled_by_id=_['student_id'],
+            assessment_requirements=STEP_REQUIREMENTS,
+            course_settings=COURSE_SETTINGS,
         )
 
         # Check to see if Buffy is actively reviewing Xander's submission.
@@ -1002,7 +1023,8 @@ class TestPeerApi(CacheResetTest):
             submission_uuid=xander_sub['uuid'],
             comments="Inappropriate language",
             cancelled_by_id=buffy['student_id'],
-            assessment_requirements=STEP_REQUIREMENTS
+            assessment_requirements=STEP_REQUIREMENTS,
+            course_settings=COURSE_SETTINGS,
         )
 
         # Check to see if Buffy is actively reviewing Xander's submission.
@@ -1037,7 +1059,8 @@ class TestPeerApi(CacheResetTest):
             submission_uuid=buffy_sub['uuid'],
             comments="Inappropriate language",
             cancelled_by_id=buffy['student_id'],
-            assessment_requirements=STEP_REQUIREMENTS
+            assessment_requirements=STEP_REQUIREMENTS,
+            course_settings=COURSE_SETTINGS,
         )
 
         workflow = PeerWorkflow.get_by_submission_uuid(buffy_sub["uuid"])
@@ -1081,7 +1104,8 @@ class TestPeerApi(CacheResetTest):
             submission_uuid=xander_answer['uuid'],
             comments="Inappropriate language",
             cancelled_by_id=buffy['student_id'],
-            assessment_requirements=STEP_REQUIREMENTS
+            assessment_requirements=STEP_REQUIREMENTS,
+            course_settings=COURSE_SETTINGS,
         )
 
         # Check to see if Buffy is actively reviewing Xander's submission.
@@ -1139,7 +1163,8 @@ class TestPeerApi(CacheResetTest):
             {
                 'must_grade': 1,
                 'must_be_graded_by': 1
-            }
+            },
+            COURSE_SETTINGS
         )
         feedback = peer_api.get_assessment_feedback(tim_sub['uuid'])
         self.assertIsNone(feedback)
@@ -1486,7 +1511,8 @@ class TestPeerApi(CacheResetTest):
             submission_uuid=xander_sub['uuid'],
             comments="Inappropriate language",
             cancelled_by_id=buffy['student_id'],
-            assessment_requirements=STEP_REQUIREMENTS
+            assessment_requirements=STEP_REQUIREMENTS,
+            course_settings=COURSE_SETTINGS,
         )
 
         # Check to see if Buffy is able to review Xander's submission.
@@ -1580,7 +1606,8 @@ class TestPeerApi(CacheResetTest):
             submission_uuid=buffy_sub['uuid'],
             comments="Inappropriate language",
             cancelled_by_id=xander['student_id'],
-            assessment_requirements=STEP_REQUIREMENTS
+            assessment_requirements=STEP_REQUIREMENTS,
+            course_settings=COURSE_SETTINGS,
         )
         self.assertTrue(peer_api.is_workflow_cancelled(submission_uuid=buffy_sub['uuid']))
 
@@ -1633,7 +1660,7 @@ class TestPeerApi(CacheResetTest):
         # enough assessments.
         # Part of the bug was that this would call `get_score()` which
         # implicitly marked peer workflow items as scored.
-        peer_api.assessment_is_finished(bob_sub['uuid'], requirements)
+        peer_api.assessment_is_finished(bob_sub['uuid'], requirements, COURSE_SETTINGS)
 
         # Sue creates a submission
         sue_sub, sue = self._create_student_and_submission('Sue', 'Sue submission')
@@ -1664,7 +1691,7 @@ class TestPeerApi(CacheResetTest):
 
         # This used to create a second assessment,
         # which was the bug.
-        score = peer_api.get_score(bob_sub['uuid'], requirements)
+        score = peer_api.get_score(bob_sub['uuid'], requirements, COURSE_SETTINGS)
 
         # Verify that only the first assessment was used to generate the score
         self.assertEqual(score['points_earned'], 14)
@@ -1776,7 +1803,7 @@ class TestPeerApi(CacheResetTest):
                 required_graded_by
             )
         # check grade of 1st submission.
-        score = peer_api.get_score(user_submissions[0][0]['uuid'], requirements)
+        score = peer_api.get_score(user_submissions[0][0]['uuid'], requirements, COURSE_SETTINGS)
 
         if is_graded:
             assert score is not None
@@ -1803,8 +1830,8 @@ class TestPeerApi(CacheResetTest):
         # The learner has not been graded by anyone, but flexible grading rounds the required 3 to .9 and casts to 0
         # The must_grade = 0 is technically disallowed by validation rules but these api calls don't care
         requirements = {'must_grade': 0, 'must_be_graded_by': 3, 'enable_flexible_grading': True}
-        self.assertEqual(1, peer_api.required_peer_grades(submission['uuid'], requirements))
-        self.assertIsNone(peer_api.get_score(submission['uuid'], requirements))
+        self.assertEqual(1, peer_api.required_peer_grades(submission['uuid'], requirements, COURSE_SETTINGS))
+        self.assertIsNone(peer_api.get_score(submission['uuid'], requirements, COURSE_SETTINGS))
 
     @staticmethod
     def _create_student_and_submission(student, answer, date=None, steps=None):
@@ -1816,8 +1843,8 @@ class TestPeerApi(CacheResetTest):
         workflow_api.create_workflow(submission["uuid"], steps or STEPS)
         return submission, new_student_item
 
-    def _assert_assessment_workflow_status(self, uuid, expected_status, step_requirements):
-        workflow = workflow_api.get_workflow_for_submission(uuid, step_requirements)
+    def _assert_assessment_workflow_status(self, uuid, expected_status, step_requirements, course_settings):
+        workflow = workflow_api.get_workflow_for_submission(uuid, step_requirements, course_settings)
         self.assertEqual(workflow['status'], expected_status)
 
     def test_get_waiting_step_details__peer_item_created_not_assessed(self):
@@ -1853,7 +1880,7 @@ class TestPeerApi(CacheResetTest):
             RUBRIC_DICT,
             step_requirements['peer']['must_be_graded_by']
         )
-        self._assert_assessment_workflow_status(target_learner_sub['uuid'], 'waiting', step_requirements)
+        self._assert_assessment_workflow_status(target_learner_sub['uuid'], 'waiting', step_requirements, COURSE_SETTINGS)
 
         # Call get_submission_to_assess once more so that target_learner has an open incomplete peer assessment
         peer_api.get_submission_to_assess(target_learner_sub['uuid'], target_learner['student_id'])
@@ -1878,7 +1905,7 @@ class TestPeerApi(CacheResetTest):
         )
 
         # The target learner is still in waiting and has five items but only one peer grade
-        self._assert_assessment_workflow_status(target_learner_sub['uuid'], 'waiting', step_requirements)
+        self._assert_assessment_workflow_status(target_learner_sub['uuid'], 'waiting', step_requirements, COURSE_SETTINGS)
         self.assertEqual(PeerWorkflow.get_by_submission_uuid(target_learner_sub['uuid']).graded_by.count(), 5)
         self.assertEqual(peer_api.get_graded_by_count(target_learner_sub['uuid']), 1)
 
@@ -1923,8 +1950,8 @@ class TestPeerApi(CacheResetTest):
         workflow.save()
 
         # It doesn't yet have a score but only requires one peer grade
-        assert peer_api.get_score(submission['uuid'], peer_requirements) is None
-        self.assertEqual(1, peer_api.required_peer_grades(submission['uuid'], peer_requirements))
+        assert peer_api.get_score(submission['uuid'], peer_requirements, COURSE_SETTINGS) is None
+        self.assertEqual(1, peer_api.required_peer_grades(submission['uuid'], peer_requirements, COURSE_SETTINGS))
 
         # The target learner assesses a peer, so they have completed their requirements.
         peer_api.get_submission_to_assess(submission['uuid'], learner['student_id'])
@@ -1961,12 +1988,12 @@ class TestPeerApi(CacheResetTest):
         # One learner reviews the target learner. The target learner has now recieved enough reviews
         # and recieves a grade (0)
         peer_assess_until_we_assess_target_submission(0, ASSESSMENT_DICT_FAIL)
-        workflow = workflow_api.update_from_assessments(submission['uuid'], assessment_requirements)
+        workflow = workflow_api.update_from_assessments(submission['uuid'], assessment_requirements, COURSE_SETTINGS)
         assert workflow['status'] == 'done'
         assert workflow['score']['points_earned'] == 0
         assert workflow['score']['points_possible'] == 14
 
-        peer_score = peer_api.get_score(submission['uuid'], peer_requirements)
+        peer_score = peer_api.get_score(submission['uuid'], peer_requirements, COURSE_SETTINGS)
         assessment_1 = Assessment.objects.get(submission_uuid=submission['uuid'])
         assert assessment_1.peerworkflowitem_set.first().scored
         assert peer_score == {
@@ -1980,8 +2007,8 @@ class TestPeerApi(CacheResetTest):
         peer_assess_until_we_assess_target_submission(1, ASSESSMENT_DICT_PASS)
         peer_assess_until_we_assess_target_submission(2, ASSESSMENT_DICT_PASS)
 
-        peer_score = peer_api.get_score(submission['uuid'], peer_requirements)
-        workflow = workflow_api.update_from_assessments(submission['uuid'], assessment_requirements)
+        peer_score = peer_api.get_score(submission['uuid'], peer_requirements, COURSE_SETTINGS)
+        workflow = workflow_api.update_from_assessments(submission['uuid'], assessment_requirements, COURSE_SETTINGS)
         item_qs = PeerWorkflowItem.objects.filter(author__student_id=learner['student_id'])
         # Get the three PeerWorkflowItems in order. Student 1, 2, 3
         items = [item_qs.get(scorer__student_id=other_learner_submissions[i][1]['student_id']) for i in [0, 1, 2]]

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -2039,6 +2039,21 @@ class TestPeerApi(CacheResetTest):
 
         assert peer_score['points_earned'] == workflow['score']['points_earned']
 
+    @unpack
+    @data(
+        (True, True, True),
+        (True, False, True),
+        (False, True, True),
+        (False, False, False)
+    )
+    def test_flexible_peer_grading_enabled(self, block_setting, course_override, expected_flexible):
+        """ Test for the behavior for flexible_peer_grading_enabled """
+        result = peer_api.flexible_peer_grading_enabled(
+            {"enable_flexible_grading": block_setting},
+            {"force_on_flexible_peer_openassessments": course_override}
+        )
+        assert result == expected_flexible
+
 
 class PeerWorkflowTest(CacheResetTest):
     """

--- a/openassessment/assessment/test/test_staff.py
+++ b/openassessment/assessment/test/test_staff.py
@@ -19,6 +19,7 @@ from openassessment.assessment.api.peer import create_assessment as peer_assess
 from openassessment.assessment.api.self import create_assessment as self_assess
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, StaffWorkflow, TeamStaffWorkflow
+from openassessment.assessment.test.test_peer import COURSE_SETTINGS
 from openassessment.test_utils import CacheResetTest
 from openassessment.tests.factories import StaffWorkflowFactory, TeamStaffWorkflowFactory, AssessmentFactory
 from openassessment.workflow import api as workflow_api
@@ -32,6 +33,7 @@ class TestStaffAssessment(CacheResetTest):
     Tests for staff assessments made as overrides, when none is required to exist.
     """
 
+    COURSE_SETTINGS = {}
     STEP_REQUIREMENTS = {}
     STEP_REQUIREMENTS_WITH_STAFF = {'required': True}
 
@@ -56,17 +58,17 @@ class TestStaffAssessment(CacheResetTest):
         ),
     ]
 
-    def _verify_done_state(self, uuid, requirements, expect_done=True):
+    def _verify_done_state(self, uuid, requirements, course_settings, expect_done=True):
         """
         Asserts that a submision and workflow are (or aren't) set to status "done".
         A False value for expect_done will confirm an assessment/workflow are NOT done.
         """
-        workflow = workflow_api.get_workflow_for_submission(uuid, requirements)
+        workflow = workflow_api.get_workflow_for_submission(uuid, requirements, course_settings)
         if expect_done:
-            self.assertTrue(staff_api.assessment_is_finished(uuid, requirements))
+            self.assertTrue(staff_api.assessment_is_finished(uuid, requirements, course_settings))
             self.assertEqual(workflow["status"], "done")
         else:
-            self.assertFalse(staff_api.assessment_is_finished(uuid, requirements))
+            self.assertFalse(staff_api.assessment_is_finished(uuid, requirements, course_settings))
             self.assertNotEqual(workflow["status"], "done")
 
     @data(*ASSESSMENT_SCORES_DDT)
@@ -91,7 +93,7 @@ class TestStaffAssessment(CacheResetTest):
         self.assertEqual(assessment["points_possible"], RUBRIC_POSSIBLE_POINTS)
 
         # Ensure submission and workflow are marked as finished
-        self._verify_done_state(tim_sub["uuid"], self.STEP_REQUIREMENTS)
+        self._verify_done_state(tim_sub["uuid"], self.STEP_REQUIREMENTS, self.COURSE_SETTINGS)
 
     @data(*ASSESSMENT_SCORES_DDT)
     def test_create_assessment_required(self, key):
@@ -103,7 +105,7 @@ class TestStaffAssessment(CacheResetTest):
         tim_sub, _ = self._create_student_and_submission("Tim", "Tim's answer", problem_steps=['staff'])
 
         # Verify that we're still waiting on a staff assessment
-        self._verify_done_state(tim_sub["uuid"], self.STEP_REQUIREMENTS_WITH_STAFF, expect_done=False)
+        self._verify_done_state(tim_sub["uuid"], self.STEP_REQUIREMENTS_WITH_STAFF, self.COURSE_SETTINGS, expect_done=False)
 
         # Verify that a StaffWorkflow step has been created and is not complete
         workflow = StaffWorkflow.objects.get(submission_uuid=tim_sub['uuid'])
@@ -119,7 +121,7 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify assesment made, score updated, and no longer waiting
         self.assertEqual(staff_assessment["points_earned"], OPTIONS_SELECTED_DICT[key]["expected_points"])
-        self._verify_done_state(tim_sub["uuid"], self.STEP_REQUIREMENTS_WITH_STAFF)
+        self._verify_done_state(tim_sub["uuid"], self.STEP_REQUIREMENTS_WITH_STAFF, self.COURSE_SETTINGS)
         # Verify that a StaffWorkflow step has been marked as complete
         workflow.refresh_from_db()
         self.assertIsNotNone(workflow.grading_completed_at)
@@ -149,7 +151,7 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify both assessment and workflow report correct score
         self.assertEqual(self_assessment["points_earned"], initial_assessment["expected_points"])
-        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], self.STEP_REQUIREMENTS)
+        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], self.STEP_REQUIREMENTS, self.COURSE_SETTINGS)
         self.assertEqual(workflow["score"]["points_earned"], initial_assessment["expected_points"])
 
         # Now override with a staff assessment
@@ -162,7 +164,7 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify both assessment and workflow report correct score
         self.assertEqual(staff_assessment["points_earned"], OPTIONS_SELECTED_DICT[key]["expected_points"])
-        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], self.STEP_REQUIREMENTS)
+        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], self.STEP_REQUIREMENTS, self.COURSE_SETTINGS)
         self.assertEqual(workflow["score"]["points_earned"], OPTIONS_SELECTED_DICT[key]["expected_points"])
 
     @data(*ASSESSMENT_TYPES_DDT)
@@ -187,7 +189,7 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify both assessment and workflow report correct score
         self.assertEqual(assessment["points_earned"], initial_assessment["expected_points"])
-        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements)
+        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements, self.STEP_REQUIREMENTS)
         self.assertEqual(workflow["score"]["points_earned"], initial_assessment["expected_points"])
 
         staff_score = "few"
@@ -201,7 +203,7 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify both assessment and workflow report correct score
         self.assertEqual(staff_assessment["points_earned"], OPTIONS_SELECTED_DICT[staff_score]["expected_points"])
-        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements)
+        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements, self.STEP_REQUIREMENTS)
         self.assertEqual(workflow["score"]["points_earned"], OPTIONS_SELECTED_DICT[staff_score]["expected_points"])
 
     @data(*ASSESSMENT_TYPES_DDT)
@@ -233,7 +235,7 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify both assessment and workflow report correct score
         self.assertEqual(staff_assessment["points_earned"], OPTIONS_SELECTED_DICT[staff_score]["expected_points"])
-        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements)
+        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements, self.STEP_REQUIREMENTS)
         # It's impossible to fake self requirements being complete, so we can't get the score for the self after_type
         if after_type != 'self':
             self.assertEqual(workflow["score"]["points_earned"], OPTIONS_SELECTED_DICT[staff_score]["expected_points"])
@@ -245,7 +247,7 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify both assessment and workflow report correct score (workflow should report previous value)
         self.assertEqual(assessment["points_earned"], unscored_assessment["expected_points"])
-        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements)
+        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements, self.STEP_REQUIREMENTS)
         self.assertEqual(workflow["score"]["points_earned"], OPTIONS_SELECTED_DICT[staff_score]["expected_points"])
 
     def test_provisionally_done(self):
@@ -290,12 +292,12 @@ class TestStaffAssessment(CacheResetTest):
         )
 
         # Verify that Bob's submission is marked done and returns the proper score
-        bob_workflow = workflow_api.get_workflow_for_submission(bob_sub["uuid"], requirements)
+        bob_workflow = workflow_api.get_workflow_for_submission(bob_sub["uuid"], requirements, self.STEP_REQUIREMENTS)
         self.assertEqual(bob_workflow["score"]["points_earned"], OPTIONS_SELECTED_DICT[staff_score]["expected_points"])
         self.assertEqual(bob_workflow["status"], "done")
 
         # Verify that Tim's submission is not marked done, and he cannot get his score
-        tim_workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements)
+        tim_workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], requirements, self.STEP_REQUIREMENTS)
         self.assertEqual(tim_workflow["score"], None)
         self.assertNotEqual(tim_workflow["status"], "done")
 
@@ -312,9 +314,9 @@ class TestStaffAssessment(CacheResetTest):
             OPTIONS_SELECTED_DICT["none"]["options"], {}, "",
             RUBRIC,
         )
-        workflow_api.get_workflow_for_submission(tim_sub["uuid"], {})
+        workflow_api.get_workflow_for_submission(tim_sub["uuid"], {}, {})
         with mock.patch('openassessment.workflow.models.sub_api.reset_score') as mock_reset:
-            workflow_api.get_workflow_for_submission(tim_sub["uuid"], {})
+            workflow_api.get_workflow_for_submission(tim_sub["uuid"], {}, {})
             self.assertFalse(mock_reset.called)
 
     def test_retrieve_bulk_workflow_status(self):
@@ -484,7 +486,7 @@ class TestStaffAssessment(CacheResetTest):
 
     def test_cancel_staff_workflow(self):
         tim_sub, _ = self._create_student_and_submission("Tim", "Tim's answer")
-        workflow_api.cancel_workflow(tim_sub['uuid'], "Test Cancel", "Bob", {})
+        workflow_api.cancel_workflow(tim_sub['uuid'], "Test Cancel", "Bob", {}, {})
         workflow = StaffWorkflow.objects.get(submission_uuid=tim_sub['uuid'])
         self.assertTrue(workflow.is_cancelled)
 
@@ -526,7 +528,7 @@ class TestStaffAssessment(CacheResetTest):
         stats = staff_api.get_staff_grading_statistics(course_id, item_id)
         self.assertEqual(stats, {'graded': 1, 'ungraded': 2, 'in-progress': 0})
 
-        workflow_api.cancel_workflow(bob_to_grade['uuid'], "Test Cancel", bob['student_id'], {})
+        workflow_api.cancel_workflow(bob_to_grade['uuid'], "Test Cancel", bob['student_id'], {}, {})
         stats = staff_api.get_staff_grading_statistics(course_id, item_id)
         self.assertEqual(stats, {'graded': 1, 'ungraded': 1, 'in-progress': 0})
 

--- a/openassessment/assessment/test/test_staff.py
+++ b/openassessment/assessment/test/test_staff.py
@@ -19,7 +19,6 @@ from openassessment.assessment.api.peer import create_assessment as peer_assess
 from openassessment.assessment.api.self import create_assessment as self_assess
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, StaffWorkflow, TeamStaffWorkflow
-from openassessment.assessment.test.test_peer import COURSE_SETTINGS
 from openassessment.test_utils import CacheResetTest
 from openassessment.tests.factories import StaffWorkflowFactory, TeamStaffWorkflowFactory, AssessmentFactory
 from openassessment.workflow import api as workflow_api
@@ -105,7 +104,12 @@ class TestStaffAssessment(CacheResetTest):
         tim_sub, _ = self._create_student_and_submission("Tim", "Tim's answer", problem_steps=['staff'])
 
         # Verify that we're still waiting on a staff assessment
-        self._verify_done_state(tim_sub["uuid"], self.STEP_REQUIREMENTS_WITH_STAFF, self.COURSE_SETTINGS, expect_done=False)
+        self._verify_done_state(
+            tim_sub["uuid"],
+            self.STEP_REQUIREMENTS_WITH_STAFF,
+            self.COURSE_SETTINGS,
+            expect_done=False
+        )
 
         # Verify that a StaffWorkflow step has been created and is not complete
         workflow = StaffWorkflow.objects.get(submission_uuid=tim_sub['uuid'])
@@ -151,7 +155,11 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify both assessment and workflow report correct score
         self.assertEqual(self_assessment["points_earned"], initial_assessment["expected_points"])
-        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], self.STEP_REQUIREMENTS, self.COURSE_SETTINGS)
+        workflow = workflow_api.get_workflow_for_submission(
+            tim_sub["uuid"],
+            self.STEP_REQUIREMENTS,
+            self.COURSE_SETTINGS
+        )
         self.assertEqual(workflow["score"]["points_earned"], initial_assessment["expected_points"])
 
         # Now override with a staff assessment
@@ -164,7 +172,11 @@ class TestStaffAssessment(CacheResetTest):
 
         # Verify both assessment and workflow report correct score
         self.assertEqual(staff_assessment["points_earned"], OPTIONS_SELECTED_DICT[key]["expected_points"])
-        workflow = workflow_api.get_workflow_for_submission(tim_sub["uuid"], self.STEP_REQUIREMENTS, self.COURSE_SETTINGS)
+        workflow = workflow_api.get_workflow_for_submission(
+            tim_sub["uuid"],
+            self.STEP_REQUIREMENTS,
+            self.COURSE_SETTINGS
+        )
         self.assertEqual(workflow["score"]["points_earned"], OPTIONS_SELECTED_DICT[key]["expected_points"])
 
     @data(*ASSESSMENT_TYPES_DDT)

--- a/openassessment/assessment/test/test_team.py
+++ b/openassessment/assessment/test/test_team.py
@@ -62,7 +62,7 @@ class TestTeamApi(CacheResetTest):
         staff_requirements = None
 
         # When I ask the API if the assessment is finished
-        api_response = teams_api.assessment_is_finished(team_submission_uuid, staff_requirements)
+        api_response = teams_api.assessment_is_finished(team_submission_uuid, staff_requirements, {})
 
         # Then it returns False
         self.assertFalse(api_response)
@@ -73,7 +73,7 @@ class TestTeamApi(CacheResetTest):
         staff_requirements = {'required': True}
 
         # When I ask the API if the assessment is finished
-        api_response = teams_api.assessment_is_finished(team_submission_uuid, staff_requirements)
+        api_response = teams_api.assessment_is_finished(team_submission_uuid, staff_requirements, {})
 
         # Then it returns False
         self.assertFalse(api_response)
@@ -85,7 +85,7 @@ class TestTeamApi(CacheResetTest):
         staff_requirements = {'required': True}
 
         # When I ask the API if the assessment is finished
-        api_response = teams_api.assessment_is_finished(team_submission_uuid, staff_requirements)
+        api_response = teams_api.assessment_is_finished(team_submission_uuid, staff_requirements, {})
 
         # Then it returns True
         self.assertTrue(api_response)
@@ -126,7 +126,7 @@ class TestTeamApi(CacheResetTest):
         staff_requirements = {'required': True}
 
         # When I use the API to get the score
-        score = teams_api.get_score(team_submission_uuid, staff_requirements)
+        score = teams_api.get_score(team_submission_uuid, staff_requirements, {})
 
         # Then None is returned
         self.assertIsNone(score)
@@ -138,7 +138,7 @@ class TestTeamApi(CacheResetTest):
         staff_requirements = {'required': True}
 
         # When I query the API for the score
-        score = teams_api.get_score(team_submission_uuid, staff_requirements)
+        score = teams_api.get_score(team_submission_uuid, staff_requirements, {})
 
         # Then the score is returned (from test constants)
         assessment = assessments[-1]

--- a/openassessment/management/commands/create_oa_submissions.py
+++ b/openassessment/management/commands/create_oa_submissions.py
@@ -154,7 +154,7 @@ class Command(BaseCommand):
         submission = sub_api.create_submission(student_item, answer)
         workflow_api.create_workflow(submission['uuid'], STEPS)
         workflow_api.update_from_assessments(
-            submission['uuid'], {'peer': {'must_grade': 1, 'must_be_graded_by': 1}}
+            submission['uuid'], {'peer': {'must_grade': 1, 'must_be_graded_by': 1}}, {}
         )
         return submission['uuid']
 

--- a/openassessment/management/commands/create_oa_submissions_from_file.py
+++ b/openassessment/management/commands/create_oa_submissions_from_file.py
@@ -304,7 +304,7 @@ class Command(BaseCommand):
                 text_response = submission_config['username'] + '\n' + generate_lorem_sentences()
                 submission = sub_api.create_submission(student_item, {'parts': [{'text': text_response}]})
                 workflow_api.create_workflow(submission['uuid'], ['staff'])
-                workflow_api.update_from_assessments(submission['uuid'], None)
+                workflow_api.update_from_assessments(submission['uuid'], None, {})
                 log.info("Created submission %s for user %s", submission['uuid'], submission_config['username'])
 
                 if submission_config['lockOwner']:
@@ -336,7 +336,7 @@ class Command(BaseCommand):
                         grade_data['overallFeedback'],
                         rubric_dict,
                     )
-                    workflow_api.update_from_assessments(submission['uuid'], None)
+                    workflow_api.update_from_assessments(submission['uuid'], None, {})
 
     def student_item(self, username, course_id, ora_display_name):
         """Helper for creating student item dicts"""

--- a/openassessment/management/tests/test_create_oa_submissions_from_file.py
+++ b/openassessment/management/tests/test_create_oa_submissions_from_file.py
@@ -241,7 +241,7 @@ class CreateSubmissionsFromFileTest(TestCase):
         # User 1 should have a submission, their workflow should be 'done', they should have a staff grade
         # and they should be locked.
         user_1_submission = sub_api.get_submissions(student_item(USERNAME_1, self.mock_block.location))[0]
-        user_1_workflow = workflow_api.get_workflow_for_submission(user_1_submission['uuid'], None)
+        user_1_workflow = workflow_api.get_workflow_for_submission(user_1_submission['uuid'], None, {})
         assert user_1_workflow['status'] == 'done'
         user_1_assessment = staff_api.get_latest_staff_assessment(user_1_submission['uuid'])
         assert user_1_assessment['points_earned'] == 1
@@ -253,7 +253,7 @@ class CreateSubmissionsFromFileTest(TestCase):
         # User 2 should have a submission, their workflow should be 'waiting', they should not have a
         # staff grade and they should not be locked
         user_2_submission = sub_api.get_submissions(student_item(USERNAME_2, self.mock_block.location))[0]
-        user_2_workflow = workflow_api.get_workflow_for_submission(user_2_submission['uuid'], None)
+        user_2_workflow = workflow_api.get_workflow_for_submission(user_2_submission['uuid'], None, {})
         assert user_2_workflow['status'] == 'waiting'
         user_2_assessment = staff_api.get_latest_staff_assessment(user_2_submission['uuid'])
         assert user_2_assessment is None
@@ -341,7 +341,7 @@ class CreateSubmissionsFromFileCallCommandTest(TestCase):
 
     def assert_submission_created(self, user, expected_graded_by, expected_locked_by):
         submission = sub_api.get_submissions(student_item(user, self.mock_block.location))[0]
-        workflow = workflow_api.get_workflow_for_submission(submission['uuid'], None)
+        workflow = workflow_api.get_workflow_for_submission(submission['uuid'], None, {})
         assessment = staff_api.get_latest_staff_assessment(submission['uuid'])
         lock = SubmissionGradingLock.get_submission_lock(submission['uuid'])
 

--- a/openassessment/tests/test_data.py
+++ b/openassessment/tests/test_data.py
@@ -162,6 +162,10 @@ STEP_REQUIREMENTS = {
     }
 }
 
+COURSE_SETTINGS = {
+    "force_on_flexible_peer_openassessments": False
+}
+
 
 @ddt.ddt
 class CsvWriterTest(TransactionCacheResetTest):
@@ -557,7 +561,7 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
         self.assertEqual(self.assessment['parts'][0]['criterion']['label'], "criterion_1")
 
         sub_api.set_score(self.submission['uuid'], self.earned_points, self.possible_points)
-        peer_api.get_score(self.submission['uuid'], STEP_REQUIREMENTS['peer'])
+        peer_api.get_score(self.submission['uuid'], STEP_REQUIREMENTS['peer'], COURSE_SETTINGS)
         self._create_assessment_feedback(self.submission['uuid'])
 
     def _create_submission(self, student_item_dict, steps=None):
@@ -606,7 +610,7 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
         feedback_dict = FEEDBACK_OPTIONS.copy()
         feedback_dict['submission_uuid'] = submission_uuid
         peer_api.set_assessment_feedback(feedback_dict)
-        workflow_api.update_from_assessments(submission_uuid, STEP_REQUIREMENTS)
+        workflow_api.update_from_assessments(submission_uuid, STEP_REQUIREMENTS, COURSE_SETTINGS)
         self.score = sub_api.get_score(STUDENT_ITEM)
 
     def _other_student(self, no_of_student):
@@ -1016,7 +1020,7 @@ class TestOraAggregateDataIntegration(TransactionCacheResetTest):
             assessments.append(assessment)
 
         sub_api.set_score(submission_uuid, 9, 10)
-        peer_api.get_score(submission_uuid, {'must_be_graded_by': 1, 'must_grade': 0})
+        peer_api.get_score(submission_uuid, {'must_be_graded_by': 1, 'must_grade': 0}, {})
         self._create_assessment_feedback(submission_uuid)
 
         # Generate the assessment report

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -145,7 +145,6 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
             Assessment-module specific errors
         """
         submission_dict = sub_api.get_submission_and_student(submission_uuid)
-        breakpoint()
         staff_auto_added = False
         if 'staff' not in step_names:
             staff_auto_added = True
@@ -348,6 +347,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
 
         new_staff_score = self.get_score(
             assessment_requirements,
+            course_settings,
             {self.STAFF_STEP_NAME: step_for_name.get(self.STAFF_STEP_NAME, None)}
         )
         if new_staff_score:
@@ -786,7 +786,7 @@ class TeamAssessmentWorkflow(AssessmentWorkflow):
 
         team_staff_step = self._team_staff_step
         team_staff_api = team_staff_step.api()
-        new_score = team_staff_api.get_score(self.team_submission_uuid, self.REQUIREMENTS)
+        new_score = team_staff_api.get_score(self.team_submission_uuid, self.REQUIREMENTS, {})
         if new_score:
             # new_score is just the most recent team score, it may already be recorded in sub_api
             old_score = sub_api.get_latest_score_for_submission(self.submission_uuid)
@@ -809,7 +809,7 @@ class TeamAssessmentWorkflow(AssessmentWorkflow):
 
             if override_submitter_requirements:
                 team_staff_step.submitter_completed_at = common_now
-            team_staff_step.update(self.team_submission_uuid, self.REQUIREMENTS)
+            team_staff_step.update(self.team_submission_uuid, self.REQUIREMENTS, {})
             self.status = self.STATUS.done
             self.save()
 

--- a/openassessment/workflow/models.py
+++ b/openassessment/workflow/models.py
@@ -145,7 +145,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
             Assessment-module specific errors
         """
         submission_dict = sub_api.get_submission_and_student(submission_uuid)
-
+        breakpoint()
         staff_auto_added = False
         if 'staff' not in step_names:
             staff_auto_added = True
@@ -203,7 +203,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         # Update the workflow (in case some of the assessment modules are automatically complete)
         # We do NOT pass in requirements, on the assumption that any assessment module
         # that accepts requirements would NOT automatically complete.
-        workflow.update_from_assessments(None)
+        workflow.update_from_assessments(None, {})
 
         # Return the newly created workflow
         return workflow
@@ -247,7 +247,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                 status_dict[step.name]['graded_by_count'] = graded_by_count
         return status_dict
 
-    def get_score(self, assessment_requirements, step_for_name):
+    def get_score(self, assessment_requirements, course_settings, step_for_name):
         """Iterate through the assessment APIs in priority order
          and return the first reported score.
 
@@ -279,7 +279,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                         step_requirements = None
                     else:
                         step_requirements = assessment_requirements.get(assessment_step_name, {})
-                    score = get_score_func(self.identifying_uuid, step_requirements)
+                    score = get_score_func(self.identifying_uuid, step_requirements, course_settings)
                     if not score and assessment_step.is_staff_step():
                         if step_requirements and step_requirements.get('required', False):
                             break  # A staff score was not found, and one is required. Return None
@@ -288,7 +288,12 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
 
         return score
 
-    def update_from_assessments(self, assessment_requirements, override_submitter_requirements=False):
+    def update_from_assessments(
+        self,
+        assessment_requirements,
+        course_settings,
+        override_submitter_requirements=False
+    ):
         """Query assessment APIs and change our status if appropriate.
 
         If the status is done, we do nothing. Once something is done, we never
@@ -327,6 +332,8 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                 can refer to this to decide whether the requirements have been
                 met.  Note that the requirements could change if the author
                 updates the problem definition.
+            course_settings (dict): Any course-level settings that may impact the
+                workflow update process.
             override_submitter_requirements (bool): If True, the presence of a new
                 staff score will cause all of the submitter's requirements to be
                 fulfilled, moving the workflow to DONE and exposing their grade.
@@ -375,7 +382,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
 
         # Go through each step and update its status.
         for step in steps:
-            step.update(self.submission_uuid, assessment_requirements)
+            step.update(self.submission_uuid, assessment_requirements, course_settings)
 
         possible_statuses = []
         skipped_statuses = []
@@ -420,10 +427,16 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
         if new_step is not None:
             new_step.start(self.submission_uuid)
 
+        # If the submitter is beginning the next assessment, notify the
+        # appropriate assessment API.
+        new_step = step_for_name.get(new_status)
+        if new_step is not None:
+            new_step.start(self.submission_uuid)
+
         # If the submitter has done all they need to do, let's check to see if
         # all steps have been fully assessed (i.e. we can score it).
         if new_status == self.STATUS.waiting and all(step.assessment_completed_at for step in steps):
-            score = self.get_score(assessment_requirements, step_for_name)
+            score = self.get_score(assessment_requirements, course_settings, step_for_name)
             # If we found a score, then we're done
             if score is not None:
                 # Only set the score if it's not a staff score, in which case it will have already been set above
@@ -542,7 +555,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                     return True
         return False
 
-    def cancel(self, assessment_requirements):
+    def cancel(self, assessment_requirements, course_settings):
         """
         Cancel workflow for all steps.
 
@@ -568,7 +581,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
                 on_cancel_func(self.identifying_uuid)
 
         try:
-            score = self.get_score(assessment_requirements, step_for_name)
+            score = self.get_score(assessment_requirements, course_settings, step_for_name)
         except AssessmentError as exc:
             logger.info("TNL-5799, exception in get_score during cancellation. %s", exc)
             score = None
@@ -589,7 +602,7 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
             )
 
     @classmethod
-    def cancel_workflow(cls, submission_uuid, comments, cancelled_by_id, assessment_requirements):
+    def cancel_workflow(cls, submission_uuid, comments, cancelled_by_id, assessment_requirements, course_settings):
         """
         Add an entry in AssessmentWorkflowCancellation table for a AssessmentWorkflow.
 
@@ -608,12 +621,14 @@ class AssessmentWorkflow(TimeStampedModel, StatusModel):
             `must_be_graded_by` to ensure that everyone will get scored.
             The intention is to eventually pass in more assessment sequence
             specific requirements in this dict.
+            course_settings (dict): Dictionary that contains course-level settings that
+            impact workflow steps
         """
         try:
             workflow = cls.objects.get(submission_uuid=submission_uuid)
             AssessmentWorkflowCancellation.create(workflow=workflow, comments=comments, cancelled_by_id=cancelled_by_id)
             # Cancel the related step's workflow.
-            workflow.cancel(assessment_requirements)
+            workflow.cancel(assessment_requirements, course_settings)
         except (cls.DoesNotExist, cls.MultipleObjectsReturned) as ex:
             error_message = f"Error finding workflow for submission UUID {submission_uuid}."
             logger.exception(error_message)
@@ -920,7 +935,7 @@ class AssessmentWorkflowStep(models.Model):
             logger.warning(msg)
             return None
 
-    def update(self, submission_uuid, assessment_requirements):
+    def update(self, submission_uuid, assessment_requirements, course_settings):
         """
         Updates the AssessmentWorkflowStep models with the requirements
         specified from the Workflow API.
@@ -947,7 +962,7 @@ class AssessmentWorkflowStep(models.Model):
             step_changed = True
 
         # Has the step received a score?
-        if not self.is_assessment_complete() and assessment_finished(submission_uuid, step_reqs):
+        if not self.is_assessment_complete() and assessment_finished(submission_uuid, step_reqs, course_settings):
             self.assessment_completed_at = now()
             step_changed = True
 
@@ -979,7 +994,7 @@ def update_workflow_async(sender, **kwargs):  # pylint: disable=unused-argument
 
     try:
         workflow = AssessmentWorkflow.objects.get(submission_uuid=submission_uuid)
-        workflow.update_from_assessments(None)
+        workflow.update_from_assessments(None, {})
     except AssessmentWorkflow.DoesNotExist:
         msg = f"Could not retrieve workflow for submission with UUID {submission_uuid}"
         logger.exception(msg)

--- a/openassessment/workflow/team_api.py
+++ b/openassessment/workflow/team_api.py
@@ -67,6 +67,9 @@ def update_from_assessments(team_submission_uuid, override_submitter_requirement
         are only assessible by staff (where requirements like "must_grade" and
         "must_be_graded_by" are not supported).
 
+        We also don't need an analogous `course_settings` parameter because there are
+        currently no course settings that impact staff grading.
+
         Raises:
             AssessmentWorkflowInternalError on error
         """
@@ -75,7 +78,7 @@ def update_from_assessments(team_submission_uuid, override_submitter_requirement
 
     # Update the workflow status based on the underlying assessments
     try:
-        team_workflow.update_from_assessments(override_submitter_requirements)
+        team_workflow.update_from_assessments(override_submitter_requirements, {})
         logger.info(
             "Updated workflow for team submission UUID %s",
             team_submission_uuid

--- a/openassessment/workflow/team_api.py
+++ b/openassessment/workflow/team_api.py
@@ -78,7 +78,7 @@ def update_from_assessments(team_submission_uuid, override_submitter_requirement
 
     # Update the workflow status based on the underlying assessments
     try:
-        team_workflow.update_from_assessments(override_submitter_requirements, {})
+        team_workflow.update_from_assessments(override_submitter_requirements)
         logger.info(
             "Updated workflow for team submission UUID %s",
             team_submission_uuid
@@ -190,7 +190,8 @@ def cancel_workflow(team_submission_uuid, comments, cancelled_by_id):
             submission_uuid,
             comments,
             cancelled_by_id,
-            TeamAssessmentWorkflow.REQUIREMENTS
+            TeamAssessmentWorkflow.REQUIREMENTS,
+            {}
         )
     except Exception as exc:
         err_msg = (

--- a/openassessment/workflow/test/test_api.py
+++ b/openassessment/workflow/test/test_api.py
@@ -109,8 +109,6 @@ class TestAssessmentWorkflowApi(CacheResetTest):
             },
             "self": {}
         }
-        
-        course_settings = {}
 
         # We'll cheat to create the workflow with the new 'special' status,
         # otherwise the creation logic will not allow unknown an unknown status
@@ -126,7 +124,7 @@ class TestAssessmentWorkflowApi(CacheResetTest):
         AssessmentWorkflow.STEPS = real_steps
 
         workflow_api.get_workflow_for_submission(
-            submission["uuid"], requirements, course_settings
+            submission["uuid"], requirements, {}
         )
 
         peer_workflows = list(PeerWorkflow.objects.filter(submission_uuid=submission["uuid"]))
@@ -135,14 +133,14 @@ class TestAssessmentWorkflowApi(CacheResetTest):
         with patch('openassessment.assessment.api.peer.submitter_is_finished') as mock_peer_submit:
             mock_peer_submit.return_value = True
             workflow = workflow_api.get_workflow_for_submission(
-                submission["uuid"], requirements, course_settings
+                submission["uuid"], requirements, {}
             )
         self.assertEqual("self", workflow['status'])
 
         with patch('openassessment.assessment.api.self.submitter_is_finished') as mock_self_submit:
             mock_self_submit.return_value = True
             workflow = workflow_api.get_workflow_for_submission(
-                submission["uuid"], requirements, course_settings
+                submission["uuid"], requirements, {}
             )
 
         self.assertEqual("waiting", workflow['status'])
@@ -160,7 +158,6 @@ class TestAssessmentWorkflowApi(CacheResetTest):
                 "must_be_graded_by": 3
             }
         }
-        course_settings = {}
         workflow_keys = set(workflow.keys())
         self.assertEqual(
             workflow_keys,
@@ -175,14 +172,14 @@ class TestAssessmentWorkflowApi(CacheResetTest):
         self.assertFalse(peer_workflows)
 
         workflow_from_get = workflow_api.get_workflow_for_submission(
-            submission["uuid"], requirements, course_settings
+            submission["uuid"], requirements, {}
         )
 
         del workflow_from_get['status_details']
         self.assertEqual(workflow, workflow_from_get)
 
         requirements["training"]["num_required"] = 0
-        workflow = workflow_api.update_from_assessments(submission["uuid"], requirements, course_settings)
+        workflow = workflow_api.update_from_assessments(submission["uuid"], requirements, {})
 
         # New step is Peer, and a Workflow has been created.
         self.assertEqual(workflow["status"], "peer")
@@ -219,7 +216,6 @@ class TestAssessmentWorkflowApi(CacheResetTest):
         with raises(workflow_api.AssessmentWorkflowInternalError):
             mock_create.side_effect = DatabaseError("Kaboom!")
             submission = sub_api.create_submission(ITEM_1, ANSWER_2)
-            breakpoint()
             workflow_api.create_workflow(submission["uuid"], ["peer", "self"])
 
     @patch('openassessment.assessment.api.staff.get_score')
@@ -399,7 +395,6 @@ class TestAssessmentWorkflowApi(CacheResetTest):
                 "must_be_graded_by": 1
             }
         }
-        course_settings = {}
 
         # Check the workflow is not cancelled.
         self.assertFalse(workflow_api.is_workflow_cancelled(submission["uuid"]))
@@ -416,7 +411,7 @@ class TestAssessmentWorkflowApi(CacheResetTest):
             comments="Inappropriate language",
             cancelled_by_id=ITEM_2['student_id'],
             assessment_requirements=requirements,
-            course_settings=course_settings,
+            course_settings={},
         )
 
         # Check workflow is cancelled.
@@ -441,7 +436,6 @@ class TestAssessmentWorkflowApi(CacheResetTest):
                 "must_be_graded_by": 1
             }
         }
-        course_settings = {}
 
         # Check if workflow is cancelled.
         self.assertFalse(workflow_api.is_workflow_cancelled(submission["uuid"]))
@@ -454,7 +448,7 @@ class TestAssessmentWorkflowApi(CacheResetTest):
                 comments="Inappropriate language",
                 cancelled_by_id=ITEM_2['student_id'],
                 assessment_requirements=requirements,
-                course_settings=course_settings,
+                course_settings={},
             )
 
         # Status for workflow should not be cancelled.
@@ -472,7 +466,6 @@ class TestAssessmentWorkflowApi(CacheResetTest):
                 "must_be_graded_by": 1
             }
         }
-        course_settings = {}
 
         # Check the workflow is not cancelled.
         self.assertFalse(workflow_api.is_workflow_cancelled(submission["uuid"]))
@@ -492,7 +485,7 @@ class TestAssessmentWorkflowApi(CacheResetTest):
             comments="Inappropriate language",
             cancelled_by_id=ITEM_2['student_id'],
             assessment_requirements=requirements,
-            course_settings=course_settings,
+            course_settings={},
         )
 
         # Check workflow is cancelled.

--- a/openassessment/workflow/test/test_signals.py
+++ b/openassessment/workflow/test/test_signals.py
@@ -54,7 +54,7 @@ class UpdateWorkflowSignalTest(CacheResetTest):
             assessment_complete_signal.send(sender=None, submission_uuid=self.submission_uuid)
 
             # Verify that the workflow model update was called
-            mock_update.assert_called_once_with(None)
+            mock_update.assert_called_once_with(None, {})
 
     @ddt.data(DatabaseError, IOError)
     @mock.patch('openassessment.workflow.models.AssessmentWorkflow.objects.get')

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -106,7 +106,11 @@ class GradeMixin:
         has_submitted_feedback = False
 
         if "peer-assessment" in assessment_steps:
-            peer_api.get_score(submission_uuid, self.workflow_requirements()["peer"])
+            peer_api.get_score(
+                submission_uuid,
+                self.self.workflow_requirements()["peer"],
+                self.get_course_workflow_settings()
+            )
             feedback = peer_api.get_assessment_feedback(submission_uuid)
             peer_assessments = [
                 self._assessment_grade_context(peer_assessment)

--- a/openassessment/xblock/grade_mixin.py
+++ b/openassessment/xblock/grade_mixin.py
@@ -108,7 +108,7 @@ class GradeMixin:
         if "peer-assessment" in assessment_steps:
             peer_api.get_score(
                 submission_uuid,
-                self.self.workflow_requirements()["peer"],
+                self.workflow_requirements()["peer"],
                 self.get_course_workflow_settings()
             )
             feedback = peer_api.get_assessment_feedback(submission_uuid)

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -313,6 +313,8 @@ class OpenAssessmentBlock(MessageMixin,
 
     @cached_property
     def course(self):
+        if not hasattr(self.runtime, "modulestore"):
+            return None
         return self.runtime.modulestore.get_course(self.scope_ids.usage_id.context_key)
 
     @property

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -310,7 +310,7 @@ class OpenAssessmentBlock(MessageMixin,
     @property
     def course_id(self):
         return str(self.xmodule_runtime.course_id)  # pylint: disable=no-member
-    
+
     @cached_property
     def course(self):
         return self.runtime.modulestore.get_course(self.scope_ids.usage_id.context_key)

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -2,6 +2,7 @@
 
 import copy
 import datetime as dt
+from functools import cached_property
 import json
 import logging
 import os
@@ -309,6 +310,10 @@ class OpenAssessmentBlock(MessageMixin,
     @property
     def course_id(self):
         return str(self.xmodule_runtime.course_id)  # pylint: disable=no-member
+    
+    @cached_property
+    def course(self):
+        return self.runtime.modulestore.get_course(self.scope_ids.usage_id.context_key)
 
     @property
     def text_response(self):

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -526,7 +526,11 @@ class StaffAreaMixin:
             peer_assessments = peer_api.get_assessments(submission_uuid)
             submitted_assessments = peer_api.get_submitted_assessments(submission_uuid)
             if grade_exists:
-                peer_api.get_score(submission_uuid, self.workflow_requirements()["peer"])
+                peer_api.get_score(
+                    submission_uuid,
+                    self.workflow_requirements()["peer"],
+                    self.get_course_workflow_settings()
+                )
                 peer_assessments_grade_context = [
                     self._assessment_grade_context(peer_assessment)
                     for peer_assessment in peer_assessments

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -710,6 +710,7 @@ class StaffAreaMixin:
         from openassessment.workflow import api as workflow_api
         try:
             assessment_requirements = self.workflow_requirements()
+            course_settings = self.get_course_workflow_settings()
             if requesting_user_id is None:
                 # The student_id is actually the bound user, which is the staff user in this context.
                 requesting_user_id = self.get_student_item_dict()["student_id"]
@@ -717,7 +718,8 @@ class StaffAreaMixin:
             workflow_api.cancel_workflow(
                 submission_uuid=submission_uuid, comments=comments,
                 cancelled_by_id=requesting_user_id,
-                assessment_requirements=assessment_requirements
+                assessment_requirements=assessment_requirements,
+                course_settings=course_settings,
             )
             return {
                 "success": True,

--- a/openassessment/xblock/staff_assessment_mixin.py
+++ b/openassessment/xblock/staff_assessment_mixin.py
@@ -58,6 +58,7 @@ class StaffAssessmentMixin:
             workflow_api.update_from_assessments(
                 assessment["submission_uuid"],
                 None,
+                {},
                 override_submitter_requirements=(assess_type == 'regrade')
             )
         except StaffAssessmentRequestError:

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -264,7 +264,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             expected_reqs = {
                 "peer": {"must_grade": 5, "must_be_graded_by": 3, "enable_flexible_grading": False}
             }
-            mock_api.update_from_assessments.assert_called_once_with('test_submission', expected_reqs)
+            mock_api.update_from_assessments.assert_called_once_with('test_submission', expected_reqs, {})
 
     @scenario('data/basic_scenario.xml')
     def test_student_view_workflow_error(self, xblock):

--- a/openassessment/xblock/test/test_peer.py
+++ b/openassessment/xblock/test/test_peer.py
@@ -167,7 +167,8 @@ class TestPeerAssessment(XBlockHandlerTestCase):
             submission_uuid=submission['uuid'],
             comments="Inappropriate language",
             cancelled_by_id=another_student['student_id'],
-            assessment_requirements=requirements
+            assessment_requirements=requirements,
+            course_settings={}
         )
 
         # Submit an assessment and expect a failure

--- a/openassessment/xblock/test/test_self.py
+++ b/openassessment/xblock/test/test_self.py
@@ -86,7 +86,7 @@ class TestSelfAssessment(XBlockHandlerTestCase):
             expected_reqs = {
                 "peer": {"must_grade": 5, "must_be_graded_by": 3, "enable_flexible_grading": False}
             }
-            mock_api.update_from_assessments.assert_called_once_with(submission['uuid'], expected_reqs)
+            mock_api.update_from_assessments.assert_called_once_with(submission['uuid'], expected_reqs, {})
 
     @scenario('data/feedback_only_criterion_self.xml', user_id='Bob')
     def test_self_assess_feedback_only_criterion(self, xblock):

--- a/openassessment/xblock/test/test_staff.py
+++ b/openassessment/xblock/test/test_staff.py
@@ -219,7 +219,7 @@ class TestStaffAssessment(StaffAssessmentTestBase):
         self.assertEqual(assessment_by_crit['𝓒𝓸𝓷𝓬𝓲𝓼𝓮'], 3)
         self.assertEqual(assessment_by_crit['Form'], 2)
 
-        score = staff_api.get_score(submission["uuid"], None)
+        score = staff_api.get_score(submission["uuid"], None, {})
         self.assertEqual(assessment['points_earned'], score['points_earned'])
         self.assertEqual(assessment['points_possible'], score['points_possible'])
 
@@ -401,7 +401,7 @@ class TestStaffTeamAssessment(StaffAssessmentTestBase):
         self.assertEqual(parts[1]['option']['name'], expected_answer['parts1_option_name'])
         self.assertEqual(parts[2]['option']['name'], expected_answer['parts2_option_name'])
 
-        score = teams_api.get_score(submission['team_submission_uuid'], {})
+        score = teams_api.get_score(submission['team_submission_uuid'], {}, {})
         self.assertEqual(assessment['points_earned'], score['points_earned'])
         self.assertEqual(assessment['points_possible'], score['points_possible'])
 

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -424,7 +424,8 @@ class TestCourseStaff(XBlockHandlerTestCase):
             submission_uuid=submission["uuid"],
             comments="Inappropriate language",
             cancelled_by_id=bob_item['student_id'],
-            assessment_requirements=requirements
+            assessment_requirements=requirements,
+            course_settings={},
         )
 
         path, context = xblock.get_student_info_path_and_context("Bob")
@@ -456,7 +457,8 @@ class TestCourseStaff(XBlockHandlerTestCase):
             submission_uuid=submission['uuid'],
             comments="Inappropriate language",
             cancelled_by_id=bob_item['student_id'],
-            assessment_requirements=requirements
+            assessment_requirements=requirements,
+            course_settings={},
         )
 
         xblock.submission_uuid = submission["uuid"]
@@ -1561,7 +1563,8 @@ class TestCourseStaff(XBlockHandlerTestCase):
                 submission_uuid=submission["uuid"],
                 comments="Inappropriate language",
                 cancelled_by_id=bob_item['student_id'],
-                assessment_requirements={}
+                assessment_requirements={},
+                course_settings={},
             )
         if grades_frozen:
             mock_are_grades_frozen = Mock(return_value=True)

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -1356,7 +1356,8 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         workflow_api.cancel_workflow(
             submission_uuid=submission['uuid'], comments='Inappropriate language',
             cancelled_by_id='Bob',
-            assessment_requirements=xblock.workflow_requirements()
+            assessment_requirements=xblock.workflow_requirements(),
+            course_settings={},
         )
 
         self._assert_path_and_context(

--- a/openassessment/xblock/test/test_workflow_mixin.py
+++ b/openassessment/xblock/test/test_workflow_mixin.py
@@ -12,12 +12,12 @@ class TestGetCourseWorkflowSettings(XBlockHandlerTestCase):
     """
     Tests for get_course_workflow_settings
     """
-    
+
     @scenario('data/basic_scenario.xml')
     def test_no_course(self, xblock):
         """ If we can't load the course, we should be returning an empty dict """
         xblock.course = None
-        assert xblock.get_course_workflow_settings() == {}    
+        assert xblock.get_course_workflow_settings() == {}
 
     @scenario("data/staff_grade_scenario.xml")
     def test_flex__no_peer_step(self, xblock):

--- a/openassessment/xblock/test/test_workflow_mixin.py
+++ b/openassessment/xblock/test/test_workflow_mixin.py
@@ -1,0 +1,34 @@
+"""
+Tests for the workflow mixin.
+"""
+
+from unittest.mock import Mock
+import ddt
+from .base import XBlockHandlerTestCase, scenario
+
+
+@ddt.ddt
+class TestGetCourseWorkflowSettings(XBlockHandlerTestCase):
+    """
+    Tests for get_course_workflow_settings
+    """
+    
+    @scenario('data/basic_scenario.xml')
+    def test_no_course(self, xblock):
+        """ If we can't load the course, we should be returning an empty dict """
+        xblock.course = None
+        assert xblock.get_course_workflow_settings() == {}    
+
+    @scenario("data/staff_grade_scenario.xml")
+    def test_flex__no_peer_step(self, xblock):
+        """ We don't include the flex override if there's no peer step """
+        xblock.course = Mock(force_on_flexible_peer_openassessments=True)
+        assert 'force_on_flexible_peer_openassessments' not in xblock.get_course_workflow_settings()
+
+    @ddt.data(True, False)
+    @scenario("data/peer_only_scenario.xml")
+    def test_flex(self, xblock, course_setting):
+        """ If there's a peer step, include the value of the course flex override """
+        xblock.course = Mock(force_on_flexible_peer_openassessments=course_setting)
+        settings = xblock.get_course_workflow_settings()
+        assert settings['force_on_flexible_peer_openassessments'] == course_setting

--- a/openassessment/xblock/workflow_mixin.py
+++ b/openassessment/xblock/workflow_mixin.py
@@ -87,7 +87,24 @@ class WorkflowMixin:
             }
 
         return requirements
+    
+    def get_course_workflow_settings(self):
+        """
+        Retrieve any course-level information that may be needed for workflow updates
+        
+        Returns:
+        {
+            'force_on_flexible_peer_openassessments': (bool) the value of the field of the same name on the course
+        } 
+        """
+        course_settings = {}
+        peer_assessment_module = self.get_assessment_module('peer-assessment')
+        if peer_assessment_module and peer_assessment_module.get("enable_flexible_grading", False):
+            course_settings['force_on_flexible_peer_openassessments'] = \
+                self.course.force_on_flexible_peer_openassessments
 
+        return course_settings                
+        
     def update_workflow_status(self, submission_uuid=None):
         """
         Update the status of a workflow.  For example, change the status
@@ -109,7 +126,8 @@ class WorkflowMixin:
 
         if submission_uuid is not None:
             requirements = self.workflow_requirements()
-            workflow_api.update_from_assessments(submission_uuid, requirements)
+            course_settings = self.get_course_workflow_settings()
+            workflow_api.update_from_assessments(submission_uuid, requirements, course_settings)
 
     def get_workflow_info(self, submission_uuid=None):
         """

--- a/openassessment/xblock/workflow_mixin.py
+++ b/openassessment/xblock/workflow_mixin.py
@@ -87,15 +87,15 @@ class WorkflowMixin:
             }
 
         return requirements
-    
+
     def get_course_workflow_settings(self):
         """
         Retrieve any course-level information that may be needed for workflow updates
-        
+
         Returns:
         {
             'force_on_flexible_peer_openassessments': (bool) the value of the field of the same name on the course
-        } 
+        }
         """
         course_settings = {}
         peer_assessment_module = self.get_assessment_module('peer-assessment')
@@ -103,8 +103,8 @@ class WorkflowMixin:
             course_settings['force_on_flexible_peer_openassessments'] = \
                 self.course.force_on_flexible_peer_openassessments
 
-        return course_settings                
-        
+        return course_settings
+
     def update_workflow_status(self, submission_uuid=None):
         """
         Update the status of a workflow.  For example, change the status
@@ -157,7 +157,9 @@ class WorkflowMixin:
         if submission_uuid is None:
             return {}
         return workflow_api.get_workflow_for_submission(
-            submission_uuid, self.workflow_requirements()
+            submission_uuid,
+            self.workflow_requirements(),
+            self.get_course_workflow_settings()
         )
 
     def get_submission_uuid(self):

--- a/openassessment/xblock/workflow_mixin.py
+++ b/openassessment/xblock/workflow_mixin.py
@@ -99,7 +99,7 @@ class WorkflowMixin:
         """
         course_settings = {}
         peer_assessment_module = self.get_assessment_module('peer-assessment')
-        if peer_assessment_module and peer_assessment_module.get("enable_flexible_grading", False):
+        if peer_assessment_module and self.course is not None:
             course_settings['force_on_flexible_peer_openassessments'] = \
                 self.course.force_on_flexible_peer_openassessments
 


### PR DESCRIPTION
**TL;DR -** Make ORA peer grading respect the course-level flexible override setting

JIRA: [AU-1288](https://2u-internal.atlassian.net/browse/AU-1288)

**What changed?**

- Created a method in the workflow mixin,  get_course_workflow_settings, which returns a dictionary, that currently only has a single key, force_on_flexible_peer_openassessments. It is intended to be a place where any future course-level fields that affect ORAs to be read from.
- Pass the value from that through .... too much stuff. We need to pass that data through several levels of API calls to get it to where it's actually needed. There is no way currently to make this less awkward.
- When we check if flex grading is turned on, we now check if the course flag is true, and then check the block.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

- Turn off the flex-grading course-wide flag
- Make an ORA that requires you to grade 1 person and be graded by 2 people, and is not flexibly graded.
- Submit submissions as two learners. They should each grade each other. They should not get grades.
- Turn on the flex-grading course-wide flag
- Manually edit one of the submissions to have been submitted more than 7 days ago (submission.submitted_at)
- Log in as each user. The learner whose submission was thrust back into the past should now have a grade. The learner who did not, should still not have a grade.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
