### PR TITLE
fix: add __init__.py to data_layer module 

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -1,4 +1,4 @@
 """
 Initialization Information for Open Assessment Module
 """
-__version__ = '5.2.2'
+__version__ = '5.2.3'

--- a/openassessment/xblock/data_layer/serializers.py
+++ b/openassessment/xblock/data_layer/serializers.py
@@ -143,7 +143,7 @@ class AssessmentStepSettingsSerializer(Serializer):
 
     def __init__(self, *args, **kwargs):
         self.step_name = kwargs.pop("step_name")
-        return super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def to_representation(self, rubric_assessments):
         assessment_step = self._get_step(rubric_assessments, self.step_name)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "5.2.1",
+      "version": "5.2.3",
       "dependencies": {
         "@edx/frontend-build": "^6.1.1",
         "@edx/paragon": "^20.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ asgiref==3.7.2
     # via django
 bleach==6.0.0
     # via -r requirements/base.in
-boto3==1.28.21
+boto3==1.28.22
     # via -r requirements/base.in
-botocore==1.31.21
+botocore==1.31.22
     # via
     #   boto3
     #   s3transfer

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -64,7 +64,7 @@ tomli==2.0.1
     #   -r requirements/tox.txt
     #   pyproject-api
     #   tox
-tox==4.6.4
+tox==4.7.0
     # via -r requirements/tox.txt
 urllib3==2.0.4
     # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,3 +31,6 @@ setuptools<60.0
 
 # incremental upgrade plan.
 django-simple-history<=3.1.1
+
+# greater version is breaking quality. Fix it in separate ticket.
+pylint<2.17.5

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -44,13 +44,13 @@ boto==2.49.0
     # via
     #   -r requirements/test.txt
     #   moto
-boto3==1.28.21
+boto3==1.28.22
     # via
     #   -r requirements/test.txt
     #   aws-sam-translator
     #   fs-s3fs
     #   moto
-botocore==1.31.21
+botocore==1.31.22
     # via
     #   -r requirements/test.txt
     #   aws-xray-sdk
@@ -397,8 +397,9 @@ pygments==2.16.1
     # via
     #   -r requirements/test.txt
     #   rich
-pylint==2.17.5
+pylint==2.17.4
     # via
+    #   -c requirements/constraints.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
@@ -481,7 +482,7 @@ pyyaml==6.0.1
     #   moto
     #   responses
     #   xblock
-regex==2023.6.3
+regex==2023.8.8
     # via
     #   -r requirements/test.txt
     #   cfn-lint
@@ -566,7 +567,7 @@ tomli==2.0.1
     #   tox
 tomlkit==0.12.1
     # via pylint
-tox==4.6.4
+tox==4.7.0
     # via -r requirements/test.txt
 types-pyyaml==6.0.12.11
     # via

--- a/requirements/test-acceptance.txt
+++ b/requirements/test-acceptance.txt
@@ -42,13 +42,13 @@ boto==2.49.0
     # via
     #   -r requirements/test.txt
     #   moto
-boto3==1.28.21
+boto3==1.28.22
     # via
     #   -r requirements/test.txt
     #   aws-sam-translator
     #   fs-s3fs
     #   moto
-botocore==1.31.21
+botocore==1.31.22
     # via
     #   -r requirements/test.txt
     #   aws-xray-sdk
@@ -453,7 +453,7 @@ pyyaml==6.0.1
     #   moto
     #   responses
     #   xblock
-regex==2023.6.3
+regex==2023.8.8
     # via
     #   -r requirements/test.txt
     #   cfn-lint
@@ -538,7 +538,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tox==4.6.4
+tox==4.7.0
     # via -r requirements/test.txt
 types-pyyaml==6.0.12.11
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -29,13 +29,13 @@ bleach==6.0.0
     # via -r requirements/base.txt
 boto==2.49.0
     # via moto
-boto3==1.28.21
+boto3==1.28.22
     # via
     #   -r requirements/base.txt
     #   aws-sam-translator
     #   fs-s3fs
     #   moto
-botocore==1.31.21
+botocore==1.31.22
     # via
     #   -r requirements/base.txt
     #   aws-xray-sdk
@@ -367,7 +367,7 @@ pyyaml==6.0.1
     #   moto
     #   responses
     #   xblock
-regex==2023.6.3
+regex==2023.8.8
     # via cfn-lint
 requests==2.31.0
     # via
@@ -431,7 +431,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tox==4.6.4
+tox==4.7.0
     # via -r requirements/test.in
 types-pyyaml==6.0.12.11
     # via responses

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -32,7 +32,7 @@ tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.6.4
+tox==4.7.0
     # via -r requirements/tox.in
 virtualenv==20.24.2
     # via tox


### PR DESCRIPTION
## Description
- Previous release `5.2.2` failed when bumping the version in edx-platform in the [PR ](https://github.com/openedx/edx-platform/pull/32939) due to insufficient files being published in the PyPI release.
- Added `__init__.py` to `xblock/data_layer` module to fix the issue.
- Bump the package version to `5.2.3` after the docs failure has been fixed. 
- If this release works successfully, the previous release `5.2.2` will need to be yanked from PyPI. 
- downgrade pylint to avoid quality failures