### PR TITLE
feat: add compatibility with individual date extensions for submissions

### DIFF
--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -14,13 +14,15 @@ TEAM_SUBMISSIONS = 'team_submissions'
 USER_STATE_UPLOAD_DATA = 'user_state_upload_data'
 RUBRIC_REUSE = 'rubric_reuse'
 ENHANCED_STAFF_GRADER = 'enhanced_staff_grader'
+DUE_DATE_EXTENSION = 'due_date_extension'
 
 FEATURE_TOGGLES_BY_FLAG_NAME = {
     ALL_FILES_URLS: 'ENABLE_ORA_ALL_FILE_URLS',
     TEAM_SUBMISSIONS: 'ENABLE_ORA_TEAM_SUBMISSIONS',
     USER_STATE_UPLOAD_DATA: 'ENABLE_ORA_USER_STATE_UPLOAD_DATA',
     RUBRIC_REUSE: 'ENABLE_ORA_RUBRIC_REUSE',
-    ENHANCED_STAFF_GRADER: 'ENABLE_ENHANCED_STAFF_GRADER'
+    ENHANCED_STAFF_GRADER: 'ENABLE_ENHANCED_STAFF_GRADER',
+    DUE_DATE_EXTENSION: 'ENABLE_ORA_DUE_DATE_EXTENSION',
 }
 
 
@@ -153,3 +155,17 @@ class ConfigMixin:
         # .. toggle_creation_date: 2021-08-29
         # .. toggle_tickets: https://openedx.atlassian.net/browse/AU-50
         return self.is_feature_enabled(ENHANCED_STAFF_GRADER)
+
+    @cached_property
+    def is_due_date_extension_enabled(self):
+        """
+        Return a boolean indicating the due date extension feature is enabled or not.
+        """
+        # .. toggle_name: FEATURES['ENABLE_ORA_DUE_DATE_EXTENSION']
+        # .. toggle_implementation: WaffleFlag
+        # .. toggle_default: False
+        # .. toggle_description: Set to True to enable the due date extension feature
+        # .. toggle_use_cases: circuit_breaker
+        # .. toggle_creation_date: 2023-08-11
+        # .. toggle_tickets: 
+        return self.is_feature_enabled(DUE_DATE_EXTENSION)

--- a/openassessment/xblock/config_mixin.py
+++ b/openassessment/xblock/config_mixin.py
@@ -167,5 +167,5 @@ class ConfigMixin:
         # .. toggle_description: Set to True to enable the due date extension feature
         # .. toggle_use_cases: circuit_breaker
         # .. toggle_creation_date: 2023-08-11
-        # .. toggle_tickets: 
+        # .. toggle_tickets:
         return self.is_feature_enabled(DUE_DATE_EXTENSION)

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -1065,6 +1065,68 @@ class OpenAssessmentBlock(
         context = {'error_msg': error_msg}
         template = get_template('openassessmentblock/oa_error.html')
         return Response(template.render(context), content_type='application/html', charset='UTF-8')
+    
+    def can_use_date_extensions(self):
+        if not self.is_due_date_extension_enabled:
+            return False
+        
+        if not self.due:
+            return False
+        
+        if not self.submission_due:
+            return False
+        
+        parsed_due = parse_date_value(self.due, self._)
+        parsed_submission_due_= parse_date_value(self.submission_due, self._)
+        
+        has_due_date_extension = parsed_due > parsed_submission_due_
+
+        if not has_due_date_extension:
+            return False
+        
+        return True
+    
+    def date_ranges(self):
+        """
+        Generate a list of dates ranges for the submission and assessment steps.
+
+        Returns:
+            submission_range (tuple): A tuple of the form (start, end) where
+                start and end are datetime objects.
+            assesment_ranges (list): A list of tuples of the form (start, end)
+                where start and end are datetime objects.
+
+        """
+        if self.can_use_date_extensions():
+
+            parsed_due = parse_date_value(self.due, self._)
+            
+            submission_range = (self.submission_start, self.due)
+            assessment_ranges = []
+
+            for assesment in self.valid_assessments:
+                assesment_due = assesment.get('due')
+
+                if assesment_due is None:
+                    assessment_ranges.append((assesment.get('start'), assesment_due))
+                    continue
+
+                parsed_assesment_due = parse_date_value(assesment_due, self._)
+
+                is_extended = parsed_due < parsed_assesment_due
+               
+                if is_extended:
+                    assessment_ranges.append((assesment.get('start'), assesment_due))
+                else:
+                    assessment_ranges.append((assesment.get('start'), self.due))
+        else:
+            submission_range = (self.submission_start, self.submission_due)
+            assessment_ranges = [
+                (asmnt.get('start'), asmnt.get('due'))
+                for asmnt in self.valid_assessments
+            ]
+        return submission_range, assessment_ranges
+
 
     def is_closed(self, step=None, course_staff=None):
         """
@@ -1106,23 +1168,7 @@ class OpenAssessmentBlock(
             datetime.datetime(2015, 3, 27, 22, 7, 38, 788861)
 
         """
-        if self.due is not None \
-           and self.submission_due is not None \
-           and parse_date_value(self.due, self._) > parse_date_value(self.submission_due, self._):
-            submission_range = (self.submission_start, self.due)
-            assessment_ranges = []
-            for asmnt in self.valid_assessments:
-                asmnt_due = asmnt.get('due')
-                if asmnt_due is None or parse_date_value(self.due, self._) < parse_date_value(asmnt_due, self._):
-                    assessment_ranges.append((asmnt.get('start'), asmnt_due))
-                else:
-                    assessment_ranges.append((asmnt.get('start'), self.due))                
-        else:
-            submission_range = (self.submission_start, self.submission_due)
-            assessment_ranges = [
-                (asmnt.get('start'), asmnt.get('due'))
-                for asmnt in self.valid_assessments
-            ]
+        submission_range, assessment_ranges = self.date_ranges()
 
         # Resolve unspecified dates and date strings to datetimes
         start, due, date_ranges = resolve_dates(

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -1106,7 +1106,12 @@ class OpenAssessmentBlock(
             datetime.datetime(2015, 3, 27, 22, 7, 38, 788861)
 
         """
-        submission_range = (self.submission_start, self.submission_due)
+        if self.due is not None \
+           and self.submission_due is not None \
+           and parse_date_value(self.due, self._) > parse_date_value(self.submission_due, self._):
+            submission_range = (self.submission_start, self.due)
+        else:
+            submission_range = (self.submission_start, self.submission_due)
         assessment_ranges = [
             (asmnt.get('start'), asmnt.get('due'))
             for asmnt in self.valid_assessments

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -1065,27 +1065,33 @@ class OpenAssessmentBlock(
         context = {'error_msg': error_msg}
         template = get_template('openassessmentblock/oa_error.html')
         return Response(template.render(context), content_type='application/html', charset='UTF-8')
-    
+
     def can_use_date_extensions(self):
+        """
+        Check if the due date extension feature is enabled.
+
+        The due date extension feature is enabled if the due date extension
+        feature flag is enabled and the student has received an date extension.
+        """
         if not self.is_due_date_extension_enabled:
             return False
-        
+
         if not self.due:
             return False
-        
+
         if not self.submission_due:
             return False
-        
-        parsed_due = parse_date_value(self.due, self._)
-        parsed_submission_due_= parse_date_value(self.submission_due, self._)
-        
-        has_due_date_extension = parsed_due > parsed_submission_due_
+
+        block_due = parse_date_value(self.due, self._)
+        submission_due = parse_date_value(self.submission_due, self._)
+
+        has_due_date_extension = block_due > submission_due
 
         if not has_due_date_extension:
             return False
-        
+
         return True
-    
+
     def date_ranges(self):
         """
         Generate a list of dates ranges for the submission and assessment steps.
@@ -1099,8 +1105,8 @@ class OpenAssessmentBlock(
         """
         if self.can_use_date_extensions():
 
-            parsed_due = parse_date_value(self.due, self._)
-            
+            block_due = parse_date_value(self.due, self._)
+
             submission_range = (self.submission_start, self.due)
             assessment_ranges = []
 
@@ -1113,8 +1119,8 @@ class OpenAssessmentBlock(
 
                 parsed_assesment_due = parse_date_value(assesment_due, self._)
 
-                is_extended = parsed_due < parsed_assesment_due
-               
+                is_extended = block_due < parsed_assesment_due
+
                 if is_extended:
                     assessment_ranges.append((assesment.get('start'), assesment_due))
                 else:
@@ -1126,7 +1132,6 @@ class OpenAssessmentBlock(
                 for asmnt in self.valid_assessments
             ]
         return submission_range, assessment_ranges
-
 
     def is_closed(self, step=None, course_staff=None):
         """

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -1110,12 +1110,19 @@ class OpenAssessmentBlock(
            and self.submission_due is not None \
            and parse_date_value(self.due, self._) > parse_date_value(self.submission_due, self._):
             submission_range = (self.submission_start, self.due)
+            assessment_ranges = []
+            for asmnt in self.valid_assessments:
+                asmnt_due = asmnt.get('due')
+                if asmnt_due is None or parse_date_value(self.due, self._) < parse_date_value(asmnt_due, self._):
+                    assessment_ranges.append((asmnt.get('start'), asmnt_due))
+                else:
+                    assessment_ranges.append((asmnt.get('start'), self.due))                
         else:
             submission_range = (self.submission_start, self.submission_due)
-        assessment_ranges = [
-            (asmnt.get('start'), asmnt.get('due'))
-            for asmnt in self.valid_assessments
-        ]
+            assessment_ranges = [
+                (asmnt.get('start'), asmnt.get('due'))
+                for asmnt in self.valid_assessments
+            ]
 
         # Resolve unspecified dates and date strings to datetimes
         start, due, date_ranges = resolve_dates(

--- a/openassessment/xblock/test/test_grade.py
+++ b/openassessment/xblock/test/test_grade.py
@@ -5,6 +5,7 @@ Tests for grade handlers in Open Assessment XBlock.
 
 import copy
 import json
+from unittest.mock import Mock
 
 import ddt
 
@@ -22,6 +23,7 @@ class TestGrade(XBlockHandlerTestCase, SubmitAssessmentsMixin):
     @scenario('data/grade_scenario.xml', user_id='Greggs')
     def test_render_grade(self, xblock):
         # Submit, assess, and render the grade view
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         self.create_submission_and_assessments(
             xblock, self.SUBMISSION, self.PEERS, PEER_ASSESSMENTS, SELF_ASSESSMENT
         )
@@ -56,6 +58,8 @@ class TestGrade(XBlockHandlerTestCase, SubmitAssessmentsMixin):
     @scenario('data/grade_scenario_self_only.xml', user_id='Greggs')
     def test_render_grade_self_only(self, xblock):
         # Submit, assess, and render the grade view
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
+
         self.create_submission_and_assessments(
             xblock, self.SUBMISSION, [], [], SELF_ASSESSMENT,
             waiting_for_peer=True
@@ -402,6 +406,7 @@ class TestGrade(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         """
         Check assessment completition status is shown correctly on assessment page.
         """
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         self.create_submission_and_assessments(
             xblock, self.SUBMISSION, peers, [PEER_ASSESSMENTS[0]] if peers else [], self_assessment
         )

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -38,6 +38,8 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         xblock_fragment = self.runtime.render(xblock, "student_view")
         self.assertIn("OpenAssessmentBlock", xblock_fragment.body_html())
 
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
+
         # Validate Submission Rendering.
         submission_response = xblock.render_submission({})
         self.assertIsNotNone(submission_response)
@@ -292,6 +294,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             time_zone_fn.return_value['user_timezone'] = pytz.timezone(time_zone)
 
             xblock = self.load_scenario('data/dates_scenario.xml')
+            xblock.is_due_date_extension_enabled = Mock(return_value=True)
             xblock_fragment = self.runtime.render(xblock, "student_view")
             self.assertIn("OpenAssessmentBlock", xblock_fragment.body_html())
 

--- a/openassessment/xblock/test/test_save_files_descriptions.py
+++ b/openassessment/xblock/test/test_save_files_descriptions.py
@@ -33,6 +33,8 @@ class SaveFilesDescriptionsTest(XBlockHandlerTestCase):
         # We're not worried about looking up shared uploads in this test
         xblock.has_team = mock.Mock(return_value=False)
 
+        xblock.is_due_date_extension_enabled = mock.Mock(return_value=True)
+
         xblock.xmodule_runtime = mock.Mock(
             user_is_staff=False,
             user_is_beta_tester=False,
@@ -65,6 +67,8 @@ class SaveFilesDescriptionsTest(XBlockHandlerTestCase):
         """
         # We're not worried about looking up shared uploads in this test
         xblock.has_team = mock.Mock(return_value=False)
+
+        xblock.is_due_date_extension_enabled = mock.Mock(return_value=True)
 
         xblock.xmodule_runtime = mock.Mock(
             user_is_staff=False,

--- a/openassessment/xblock/test/test_save_response.py
+++ b/openassessment/xblock/test/test_save_response.py
@@ -19,6 +19,8 @@ class SaveResponseTest(XBlockHandlerTestCase):
     def test_default_saved_response_blank(self, xblock):
         xblock.get_team_info = mock.Mock(return_value={})
 
+        xblock.is_due_date_extension_enabled = mock.Mock(return_value=True)
+
         xblock.xmodule_runtime = mock.Mock(
             user_is_staff=False,
             user_is_beta_tester=False,
@@ -33,6 +35,8 @@ class SaveResponseTest(XBlockHandlerTestCase):
     @scenario('data/save_scenario.xml', user_id="Perleman")
     def test_save_response(self, xblock, data):
         xblock.get_team_info = mock.Mock(return_value={})
+
+        xblock.is_due_date_extension_enabled = mock.Mock(return_value=True)
 
         xblock.xmodule_runtime = mock.Mock(
             user_is_staff=False,

--- a/openassessment/xblock/test/test_self.py
+++ b/openassessment/xblock/test/test_self.py
@@ -435,6 +435,8 @@ class TestSelfAssessmentRender(XBlockHandlerTestCase):
             xblock.get_student_item_dict(), ("Test submission 1", "Test submission 2")
         )
 
+        xblock.is_due_date_extension_enabled = mock.Mock(return_value=True)
+
         xblock.get_workflow_info = mock.Mock(return_value={
             'status': 'self', 'submission_uuid': submission['uuid']
         })

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -127,6 +127,7 @@ class TestCourseStaff(XBlockHandlerTestCase):
     @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_course_staff_area(self, xblock):
         # If we're not course staff, we shouldn't see the staff area
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         xblock.xmodule_runtime = self._create_mock_runtime(
             xblock.scope_ids.usage_id, False, False, "Bob"
         )
@@ -140,6 +141,7 @@ class TestCourseStaff(XBlockHandlerTestCase):
 
     @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_view_in_studio_button(self, xblock):
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         xblock.xmodule_runtime = self._create_mock_runtime(
             xblock.scope_ids.usage_id, False, False, "Bob"
         )
@@ -210,6 +212,8 @@ class TestCourseStaff(XBlockHandlerTestCase):
     @scenario('data/staff_dates_scenario.xml', user_id='Bob')
     def test_staff_area_dates_table(self, xblock):
         # Simulate that we are course staff
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
+
         xblock.xmodule_runtime = self._create_mock_runtime(
             xblock.scope_ids.usage_id, True, False, "Bob"
         )
@@ -232,6 +236,8 @@ class TestCourseStaff(XBlockHandlerTestCase):
     @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_staff_area_dates_distant_past_and_future(self, xblock):
         # Simulate that we are course staff
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
+
         xblock.xmodule_runtime = self._create_mock_runtime(
             xblock.scope_ids.usage_id, True, False, "Bob"
         )
@@ -1116,6 +1122,7 @@ class TestCourseStaff(XBlockHandlerTestCase):
 
     @scenario('data/team_submission.xml', user_id='Bob')
     def test_staff_area_has_team_info(self, xblock):
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         # Given that we are course staff, managing a team assignment
         self._setup_xblock_and_create_submission(xblock)
 
@@ -1140,6 +1147,7 @@ class TestCourseStaff(XBlockHandlerTestCase):
     @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_staff_area_has_team_info_individual(self, xblock):
         # Given that we are course staff, managing an individual assignment
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         self._setup_xblock_and_create_submission(xblock)
 
         # When I get the staff context

--- a/openassessment/xblock/test/test_student_training.py
+++ b/openassessment/xblock/test/test_student_training.py
@@ -199,6 +199,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
 
     @scenario('data/feedback_only_criterion_student_training.xml', user_id='Bob')
     def test_feedback_only_criterion(self, xblock):
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         xblock.create_submission(xblock.get_student_item_dict(), self.SUBMISSION)
         self.request(xblock, 'render_student_training', json.dumps({}))
 
@@ -264,6 +265,7 @@ class StudentTrainingAssessTest(StudentTrainingTest):
                 'Grammar': 'Poor'
             }
         }
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         resp = self.request(xblock, 'training_assess', json.dumps(selected_data))
         self.assertIn("Your scores could not be checked", resp.decode('utf-8'))
 
@@ -315,11 +317,13 @@ class StudentTrainingRenderTest(StudentTrainingTest):
 
     @scenario('data/student_training.xml', user_id="Plato")
     def test_no_submission(self, xblock):
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         resp = self.request(xblock, 'render_student_training', json.dumps({}))
         self.assertIn("Not Available", resp.decode('utf-8'))
 
     @scenario('data/student_training.xml')
     def test_studio_preview(self, xblock):
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         resp = self.request(xblock, 'render_student_training', json.dumps({}))
         self.assertIn("Not Available", resp.decode('utf-8'))
 

--- a/openassessment/xblock/test/test_submission.py
+++ b/openassessment/xblock/test/test_submission.py
@@ -150,6 +150,7 @@ class SubmissionTest(SubmissionXBlockHandlerTestCase):
 
     @scenario('data/over_grade_scenario.xml', user_id='Alice')
     def test_closed_submissions(self, xblock):
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         resp = self.request(xblock, 'render_submission', json.dumps({}))
         self.assertIn("Incomplete", resp.decode('utf-8'))
 
@@ -157,12 +158,14 @@ class SubmissionTest(SubmissionXBlockHandlerTestCase):
     def test_prompt_line_breaks(self, xblock):
         # Verify that prompts with multiple lines retain line breaks
         # (backward compatibility in case if prompt_type == 'text')
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         resp = self.request(xblock, 'render_submission', json.dumps({}))
         expected_prompt = "<p><br>Line 1</p><p>Line 2</p><p>Line 3<br></p>"
         self.assertIn(expected_prompt, resp.decode('utf-8'))
 
     @scenario('data/prompt_html.xml')
     def test_prompt_html_to_text(self, xblock):
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         resp = self.request(xblock, 'render_submission', json.dumps({}))
         expected_prompt = "<code><strong>Question 123</strong></code>"
         self.assertIn(expected_prompt, resp.decode('utf-8'))
@@ -948,6 +951,8 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
 
         xblock.file_manager.append_uploads(*file_uploads)
 
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
+
         # Save a response
         payload = json.dumps({'submission': ('A man must have a code', 'A man must have an umbrella too.')})
         resp = self.request(xblock, 'save_submission', payload, response_format='json')
@@ -1030,6 +1035,8 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
             course_id='test_course',
             anonymous_student_id='Pmn'
         )
+
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
 
         # delete file-2
         with patch('openassessment.fileupload.api.remove_file'):
@@ -1197,6 +1204,7 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
         Test that we render files owned by Valchek and
         their teammates when files are shared with a team.
         """
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
         xblock.file_manager.get_uploads = Mock(return_value=[
             api.FileUpload(
                 description='file 1 description',
@@ -1600,6 +1608,8 @@ class SubmissionRenderTest(SubmissionXBlockHandlerTestCase):
     @scenario('data/submission_open.xml', user_id="Bob")
     def test_integration(self, xblock):
         # Expect that the response step is open and displays the deadline
+        xblock.is_due_date_extension_enabled = Mock(return_value=True)
+
         resp = self.request(xblock, 'render_submission', json.dumps({}))
         self.assertIn('Enter your response to the prompt', resp.decode('utf-8'))
         self.assertIn('2999-05-06T00:00:00+00:00', resp.decode('utf-8'))

--- a/settings/base.py
+++ b/settings/base.py
@@ -167,7 +167,10 @@ FEATURES = {
 
     # Set to True to enable copying/reusing rubric data
     # See: https://openedx.atlassian.net/browse/EDUCATOR-5751
-    'ENABLE_ORA_RUBRIC_REUSE': False
+    'ENABLE_ORA_RUBRIC_REUSE': False,
+
+    # Set to True to enable individual due date extension for ORA
+    'ENABLE_ORA_DUE_DATE_EXTENSION': False,
 }
 
 # disable indexing on history_date


### PR DESCRIPTION
**TL;DR -** Adds compatibility with individual date extensions behind a waffle flag

Partially fixes: https://github.com/openedx/edx-ora2/issues/1959

**What changed?**

- If the `due` date of the submission is greater than the `submission_due` date, `due` is used for the `submission_range`.
- If the `due` date of the assessment step is greater than the `assessment_due` date, `due` is used for the `assesment_step` range.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

Add a waffle flag for everyone: `openresponseassessment.due_date_extension`

1. Go to the CMS
2. Add a default ORA component with any assessment steps.
3. Set a due date for the Section to yesterday.
4. Verify user can't answer the ORA.
5. Go to the instructor tab, extensions, and grant an individual due date for that section.
6. Verify user can answer the problem.

Before this change, users were unable to answer:

![image](https://github.com/openedx/edx-ora2/assets/33465240/87baef4f-009c-42dd-9e53-44db5ac6cbd4)

After setting a due date for yesterday:

![image](https://github.com/openedx/edx-ora2/assets/33465240/d4dc97d8-b7e6-488b-94e1-fd9f05fc011e)

After granting an individual date extension:

![image](https://github.com/openedx/edx-ora2/assets/33465240/2614cebd-d7b3-4c22-8efd-5049484a7467)

The second commit allows us to apply the individual due date extension for every step in the workflow:

https://github.com/openedx/edx-ora2/pull/2026/commits/c005190f6f2cf137183ae12f9a566c64d7d208c6

![image](https://github.com/openedx/edx-ora2/assets/33465240/2dd98be0-eada-45ae-8c7b-5f6d6e5eff41)

![image](https://github.com/openedx/edx-ora2/assets/33465240/4e45ef3e-8504-4602-afc3-b7077003dfff)

**Things to consider**

Unit tests will be added once we receive our first product review and concerns are resolved

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
