### PR TITLE
fix: Replaced UsageKey with CourseKey for the course lookup

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '5.5.1'
+__version__ = '5.5.2'

--- a/openassessment/workflow/test/test_workflow_batch_update_api.py
+++ b/openassessment/workflow/test/test_workflow_batch_update_api.py
@@ -145,9 +145,14 @@ class TestWorkflowBatchUpdateAPI(CacheResetTest):
 
     @patch('openassessment.workflow.workflow_batch_update_api.modulestore')
     @patch('openassessment.workflow.workflow_batch_update_api.UsageKey.from_string')
-    def test_get_workflow_update_data(self, mocked_from_string, mocked_modulestore):
+    @patch('openassessment.workflow.workflow_batch_update_api.CourseKey.from_string')
+    def test_get_workflow_update_data(self,
+                                      mocked_usage_key_from_string,
+                                      mocked_course_key_from_string,
+                                      mocked_modulestore):
         mocked_modulestore.return_value = MockModulestore()
-        mocked_from_string.side_effect = mock_from_string
+        mocked_usage_key_from_string.side_effect = mock_from_string
+        mocked_course_key_from_string.side_effect = mock_from_string
 
         peer_workflows = self.get_peer_workflows()
         wup = update_api.get_workflow_update_data(peer_workflows)

--- a/openassessment/workflow/workflow_batch_update_api.py
+++ b/openassessment/workflow/workflow_batch_update_api.py
@@ -7,7 +7,7 @@ import time
 import datetime
 from django.utils import timezone
 
-from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.keys import UsageKey, CourseKey
 from openassessment.runtime_imports.functions import modulestore
 from openassessment.assessment.models import PeerWorkflow
 from openassessment.workflow import api
@@ -315,7 +315,7 @@ def get_workflow_update_data(peer_workflows):
         try:
             if peer_workflow.course_id not in course_settings_cache:
                 # retrieve course block from DB
-                course_block_key = UsageKey.from_string(peer_workflow.course_id)
+                course_block_key = CourseKey.from_string(peer_workflow.course_id)
                 course_block = store.get_item(course_block_key)
                 # add course settings to temp cache
                 course_settings_cache[peer_workflow.course_id] = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.5.0",
+  "version": "5.5.2",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** I have missed the fact that PeerWorkflow.course_id returns course_key, not a location and attempted to construct UsageKey. Replacing UsageKey with CourseKey to fix the problem.


**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
