### PR TITLE
fix: using get_course for course lookup in modulestore

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '5.5.2'
+__version__ = '5.5.3'

--- a/openassessment/workflow/test/test_workflow_batch_update_api.py
+++ b/openassessment/workflow/test/test_workflow_batch_update_api.py
@@ -427,5 +427,6 @@ class MockModulestore:
             return MockCourseBlock(False)
 
         return None
+
     def get_course(self, block_key):
         return self.get_item(block_key)

--- a/openassessment/workflow/test/test_workflow_batch_update_api.py
+++ b/openassessment/workflow/test/test_workflow_batch_update_api.py
@@ -427,3 +427,5 @@ class MockModulestore:
             return MockCourseBlock(False)
 
         return None
+    def get_course(self, block_key):
+        return self.get_item(block_key)

--- a/openassessment/workflow/workflow_batch_update_api.py
+++ b/openassessment/workflow/workflow_batch_update_api.py
@@ -316,7 +316,7 @@ def get_workflow_update_data(peer_workflows):
             if peer_workflow.course_id not in course_settings_cache:
                 # retrieve course block from DB
                 course_block_key = CourseKey.from_string(peer_workflow.course_id)
-                course_block = store.get_item(course_block_key)
+                course_block = store.get_course(course_block_key)
                 # add course settings to temp cache
                 course_settings_cache[peer_workflow.course_id] = {
                     'force_on_flexible_peer_openassessments': course_block.force_on_flexible_peer_openassessments}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** As it turns out to do course block lookup using `modulestore` and `CourseKey` we need to call `get_course` method, `get_item` gives error when passing `CourseKey` 


**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
