### PR TITLE
feat: draft assessment response serializer

### DIFF
--- a/openassessment/assessment/api/staff.py
+++ b/openassessment/assessment/api/staff.py
@@ -12,7 +12,12 @@ from submissions import api as submissions_api
 
 from openassessment.assessment.errors import StaffAssessmentInternalError, StaffAssessmentRequestError
 from openassessment.assessment.models import Assessment, AssessmentPart, InvalidRubricSelection, StaffWorkflow
-from openassessment.assessment.serializers import InvalidRubric, full_assessment_dict, rubric_from_dict
+from openassessment.assessment.serializers import (
+    InvalidRubric,
+    full_assessment_dict,
+    rubric_from_dict,
+    serialize_assessments,
+)
 from openassessment.assessment.score_type_constants import STAFF_TYPE
 
 
@@ -462,3 +467,34 @@ def bulk_retrieve_workflow_status(course_id, item_id, submission_uuids=None):
     return StaffWorkflow.bulk_retrieve_workflow_status(
         course_id, item_id, submission_uuids
     )
+
+
+def get_assessment(submission_uuid):
+    """
+    Retrieve a staff-assessment for a submission_uuid.
+
+    Args:
+        submission_uuid (str): The submission UUID for we want information for
+            regarding staff assessment.
+
+    Returns:
+        assessment (dict) is a serialized Assessment model, or None (if the user has not yet self-assessed)
+        If multiple submissions or staff-assessments are found, returns the most recent one.
+    """
+    # Retrieve assessments for the submission UUID
+    # We weakly enforce that number of staff-assessments per submission is <= 1,
+    # but not at the database level.  Someone could take advantage of the race condition
+    # between checking the number of staff-assessments and creating a new staff-assessment.
+    # To be safe, we retrieve just the most recent submission.
+    serialized_assessments = serialize_assessments(Assessment.objects.filter(
+        score_type=STAFF_TYPE, submission_uuid=submission_uuid
+    ).order_by('-scored_at')[:1])
+
+    if not serialized_assessments:
+        logger.info("No staff-assessment found for submission %s", submission_uuid)
+        return None
+
+    serialized_assessment = serialized_assessments[0]
+    logger.info("Retrieved staff-assessment for submission %s", submission_uuid)
+
+    return serialized_assessment

--- a/openassessment/xblock/apis/assessments/peer_assessment_api.py
+++ b/openassessment/xblock/apis/assessments/peer_assessment_api.py
@@ -25,6 +25,10 @@ class PeerAssessmentAPI(StepDataAPI):
         return self.config_data.get_assessment_module("peer-assessment")
 
     @property
+    def assessments(self):
+        return peer_api.get_assessments(self.submission_uuid)
+
+    @property
     def continue_grading(self):
         return self._continue_grading and self.workflow_data.is_peer_complete
 

--- a/openassessment/xblock/apis/assessments/staff_assessment_api.py
+++ b/openassessment/xblock/apis/assessments/staff_assessment_api.py
@@ -38,6 +38,10 @@ class StaffAssessmentAPI(StepDataAPI):
             self.config_data.prompts, self.config_data.rubric_criteria_with_labels
         )
 
+    @property
+    def assessment(self):
+        return staff_api.get_assessment(self.workflow_data.workflow.get("submission_uuid"))
+
     def create_team_assessment(self, data):
         team_submission = team_sub_api.get_team_submission_from_individual_submission(
             data["submission_uuid"]

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -50,7 +50,7 @@ class MfeMixin:
 
     @XBlock.json_handler
     def get_block_learner_assessment_data(self, data, suffix=""):  # pylint: disable=unused-argument
-        serializer_context = {"view": "assessment"}
+        serializer_context = {"view": "assessment", "step": suffix}
 
         # Allow jumping to a specific step, within our allowed steps
         # NOTE should probably also verify this step is in our assessment steps

--- a/openassessment/xblock/ui_mixins/mfe/ora_config_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/ora_config_serializer.py
@@ -85,7 +85,7 @@ class RubricCriterionSerializer(Serializer):
     name = CharField(source="label")
     description = CharField(source="prompt")
     feedbackEnabled = SerializerMethodField()
-    feedbackRequired = IsRequiredField(source="feedback")
+    feedbackRequired = SerializerMethodField()
     options = RubricCriterionOptionSerializer(many=True)
 
     @staticmethod
@@ -96,6 +96,10 @@ class RubricCriterionSerializer(Serializer):
     def get_feedbackEnabled(self, criterion):
         # Feedback can be specified as optional or required
         return self._feedback(criterion) != "disabled"
+
+    def get_feedbackRequired(self, criterion):
+        # Feedback can be specified as optional or required
+        return self._feedback(criterion) == "required"
 
 
 class RubricConfigSerializer(Serializer):

--- a/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
@@ -1,16 +1,22 @@
 """
 Tests for AssessmentResponseSerializer
 """
+import json
 from unittest.mock import patch
 
 from openassessment.fileupload.api import FileUpload
 from openassessment.xblock.test.base import (
+    PEER_ASSESSMENTS,
+    STAFF_GOOD_ASSESSMENT,
     SubmissionTestMixin,
+    SubmitAssessmentsMixin,
     XBlockHandlerTestCase,
     scenario,
 )
 from openassessment.xblock.ui_mixins.mfe.assessment_serializers import (
     AssessmentResponseSerializer,
+    AssessmentStepSerializer,
+    AssessmentGradeSerializer,
 )
 
 
@@ -25,7 +31,7 @@ class TestAssessmentResponseSerializer(XBlockHandlerTestCase, SubmissionTestMixi
     @scenario("data/basic_scenario.xml", user_id="Alan")
     def test_no_response(self, xblock):
         # Given we are asking for assessment data too early (still on submission step)
-        context = {"response": None}
+        context = {"response": None, "step": "submission"}
 
         # When I load my response
         data = AssessmentResponseSerializer(xblock.api_data, context=context).data
@@ -47,7 +53,7 @@ class TestAssessmentResponseSerializer(XBlockHandlerTestCase, SubmissionTestMixi
         submission = self.create_test_submission(
             xblock, submission_text=submission_text
         )
-        context = {"response": submission}
+        context = {"response": submission, "step": "self"}
 
         # When I load my response
         data = AssessmentResponseSerializer(xblock.api_data, context=context).data
@@ -72,7 +78,7 @@ class TestAssessmentResponseSerializer(XBlockHandlerTestCase, SubmissionTestMixi
         submission = self.create_test_submission(
             xblock, submission_text=submission_text
         )
-        context = {"response": submission}
+        context = {"response": submission, "step": "self"}
 
         # When I load my response
         data = AssessmentResponseSerializer(xblock.api_data, context=context).data
@@ -138,7 +144,7 @@ class TestAssessmentResponseSerializer(XBlockHandlerTestCase, SubmissionTestMixi
         )
 
         # When I load my response
-        context = {"response": submission}
+        context = {"response": submission, "step": "self"}
         data = AssessmentResponseSerializer(xblock.api_data, context=context).data
 
         # I get the appropriate response (test URLs use usage ID)
@@ -169,3 +175,100 @@ class TestAssessmentResponseSerializer(XBlockHandlerTestCase, SubmissionTestMixi
         self.assertIsNone(data["hasCancelled"])
         self.assertIsNone(data["hasReceivedGrade"])
         self.assertIsNone(data["teamInfo"])
+
+
+class TestAssessmentGradeSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixin):
+    ASSESSMENT = {
+        'options_selected': {'𝓒𝓸𝓷𝓬𝓲𝓼𝓮': 'ﻉซƈﻉɭɭﻉกՇ', 'Form': 'Fair'},
+        'criterion_feedback': {},
+        'overall_feedback': ""
+    }
+
+    @scenario("data/self_assessment_scenario.xml", user_id="Alan")
+    def test_self_assessment_step(self, xblock):
+        submission_text = ["Foo", "Bar"]
+
+        submission = self.create_test_submission(
+            xblock, submission_text=submission_text
+        )
+
+        context = {"response": submission, "step": "self"}
+
+        resp = self.request(
+            xblock, "self_assess", json.dumps(self.ASSESSMENT), response_format="json"
+        )
+        self.assertTrue(resp["success"])
+
+        # When I load my response
+        data = AssessmentGradeSerializer(xblock.api_data, context=context).data
+        # I get the appropriate response
+        self.assertEqual(context["step"], data["effectiveAssessmentType"])
+        self.assertEqual(
+            data["self"],
+            AssessmentStepSerializer(
+                xblock.api_data.self_assessment_data.assessment, context=context
+            ).data,
+        )
+
+    @scenario("data/grade_scenario.xml", user_id="Alan")
+    def test_staff_assessment_step(self, xblock):
+        submission_text = ["Foo", "Bar"]
+        submission = self.create_test_submission(
+            xblock, submission_text=submission_text
+        )
+
+        self.submit_staff_assessment(xblock, submission, STAFF_GOOD_ASSESSMENT)
+
+        context = {"response": submission, "step": "staff"}
+        # When I load my response
+        data = AssessmentGradeSerializer(xblock.api_data, context=context).data
+
+        # I get the appropriate response
+        self.assertEqual(context["step"], data["effectiveAssessmentType"])
+        self.assertEqual(
+            data["staff"],
+            AssessmentStepSerializer(
+                xblock.api_data.staff_assessment_data.assessment, context=context
+            ).data,
+        )
+
+    @scenario("data/grade_scenario.xml", user_id="Bernard")
+    def test_peer_assement_steps(self, xblock):
+        # Create a submission from the user
+        student_item = xblock.get_student_item_dict()
+        submission = self.create_test_submission(
+            xblock, student_item=student_item, submission_text=self.SUBMISSION
+        )
+
+        # Create submissions from other users
+        scorer_subs = self.create_peer_submissions(
+            student_item, self.PEERS, self.SUBMISSION
+        )
+
+        graded_by = xblock.get_assessment_module("peer-assessment")["must_be_graded_by"]
+        for scorer_sub, scorer_name, assessment in list(
+            zip(scorer_subs, self.PEERS, PEER_ASSESSMENTS)
+        )[:-1]:
+            self.create_peer_assessment(
+                scorer_sub,
+                scorer_name,
+                submission,
+                assessment,
+                xblock.rubric_criteria,
+                graded_by,
+            )
+
+        context = {"response": submission, "step": "peer"}
+
+        # When I load my response
+        data = AssessmentGradeSerializer(xblock.api_data, context=context).data
+
+        # I get the appropriate response
+        self.assertEqual(context["step"], data["effectiveAssessmentType"])
+        for i in range(len(data["peers"])):
+            peer = data["peers"][i]
+            serialize_peer = AssessmentStepSerializer(
+                xblock.api_data.peer_assessment_data().assessments[i], context=context
+            ).data
+            self.assertEqual(serialize_peer["stepScore"], peer["stepScore"])
+            self.assertEqual(serialize_peer["assessment"], serialize_peer["assessment"])


### PR DESCRIPTION
Merge to **feat/2023-dual-ui**

What changed:
- implementation for assessment response

Test:
- go to `/xblock/:id/handler/get_block_learner_assessment_data/self`
- `/xblock/:id/handler/get_block_learner_assessment_data/staff`,
- `/xblock/:id/handler/get_block_learner_assessment_data/peer`

