### PR TITLE
refactor: Step Info contract updates

### DIFF
--- a/openassessment/xblock/apis/step_data_api.py
+++ b/openassessment/xblock/apis/step_data_api.py
@@ -1,4 +1,5 @@
 """ Base class for step data collations """
+from openassessment.xblock.apis.workflow_api import WorkflowStep
 from openassessment.xblock.utils.resolve_dates import DISTANT_FUTURE
 
 
@@ -10,6 +11,7 @@ class StepDataAPI:
         self._closed_reason = closed_reason
         self._start_date = start_date
         self._due_date = due_date
+        self._step = WorkflowStep(step)
 
     def __repr__(self):
         return "{0}".format(
@@ -28,6 +30,16 @@ class StepDataAPI:
     @property
     def workflow_data(self):
         return self._block.api_data.workflow_data
+
+    @property
+    def has_reached_step(self):
+        """Util for determining if we have reached or surpassed this step"""
+        if self.workflow_data.status == self._step:
+            return True
+        step_info = self.workflow_data.status_details.get(str(self._step), {})
+        if step_info.get("complete"):
+            return True
+        return False
 
     @property
     def problem_closed(self):

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -3,6 +3,9 @@ Exposed api for ORA XBlock workflows.
 """
 
 
+from enum import Enum
+
+
 class WorkflowAPI:
     def __init__(self, block):
         self._block = block
@@ -108,3 +111,62 @@ class WorkflowAPI:
 
     def get_team_workflow_cancellation_info(self, team_submission_uuid):
         return self._block.get_team_workflow_cancellation_info(team_submission_uuid)
+
+
+class WorkflowStep:
+    """Utility class for comparing and serializing steps"""
+
+    # Store one disambiguated step
+    canonical_step = None
+    step_name = None
+
+    # Enum of workflow steps, used for canonical mapping of steps
+    class Step(Enum):
+        SUBMISSION = "submission"
+        PEER = "peer"
+        STUDENT_TRAINING = "training"
+        STAFF = "staff"
+        SELF = "self"
+        AI = "ai"
+
+    _assessment_module_mappings = {
+        "peer-assessment": Step.PEER,
+        "student-training": Step.STUDENT_TRAINING,
+        "staff-assessment": Step.STAFF,
+        "self-assessment": Step.SELF,
+    }
+
+    _workflow_step_mappings = {
+        "submission": Step.SUBMISSION,
+        "training": Step.STUDENT_TRAINING,
+        "peer": Step.PEER,
+        "self": Step.SELF,
+        "staff": Step.STAFF,
+    }
+
+    _step_mappings = {**_assessment_module_mappings, **_workflow_step_mappings}
+
+    @property
+    def assessment_module_name(self):
+        """ Get the assessment module name for the step """
+        for assessment, canonical_step in self._assessment_module_mappings:
+            if canonical_step == self.canonical_step:
+                return self._assessment_module_mappings[assessment]
+
+    @property
+    def workflow_step_name(self):
+        """ Get the workflow step name for the step """
+        for workflow_step, canonical_step in self._assessment_module_mappings:
+            if canonical_step == self.canonical_step:
+                return self._workflow_step_mappings[workflow_step]
+
+    def __init__(self, step_name):
+        # Get the "canonical" step from any representation of the step name
+        self.step_name = step_name
+        self.canonical_step = self._step_mappings.get(step_name)
+
+    def __eq__(self, __value: object) -> bool:
+        return self.canonical_step == self._step_mappings.get(__value)
+
+    def __repr__(self) -> str:
+        return str(self.canonical_step)

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -149,16 +149,16 @@ class WorkflowStep:
     @property
     def assessment_module_name(self):
         """ Get the assessment module name for the step """
-        for assessment, canonical_step in self._assessment_module_mappings:
+        for assessment_step, canonical_step in self._assessment_module_mappings.items():
             if canonical_step == self.canonical_step:
-                return self._assessment_module_mappings[assessment]
+                return assessment_step
 
     @property
     def workflow_step_name(self):
         """ Get the workflow step name for the step """
-        for workflow_step, canonical_step in self._assessment_module_mappings:
+        for workflow_step, canonical_step in self._workflow_step_mappings.items():
             if canonical_step == self.canonical_step:
-                return self._workflow_step_mappings[workflow_step]
+                return workflow_step
 
     def __init__(self, step_name):
         # Get the "canonical" step from any representation of the step name

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -152,6 +152,7 @@ class WorkflowStep:
         for assessment_step, canonical_step in self._assessment_module_mappings.items():
             if canonical_step == self.canonical_step:
                 return assessment_step
+        return "unknown"
 
     @property
     def workflow_step_name(self):
@@ -159,6 +160,7 @@ class WorkflowStep:
         for workflow_step, canonical_step in self._workflow_step_mappings.items():
             if canonical_step == self.canonical_step:
                 return workflow_step
+        return "unknown"
 
     def __init__(self, step_name):
         # Get the "canonical" step from any representation of the step name

--- a/openassessment/xblock/ui_mixins/mfe/ora_config_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/ora_config_serializer.py
@@ -13,8 +13,10 @@ from rest_framework.serializers import (
     CharField,
     SerializerMethodField,
 )
+from openassessment.xblock.apis.workflow_api import WorkflowStep
 
 from openassessment.xblock.ui_mixins.mfe.serializer_utils import (
+    STEP_NAME_MAPPINGS,
     CharListField,
     IsRequiredField,
 )
@@ -161,7 +163,7 @@ class AssessmentStepSettingsSerializer(Serializer):
 
 
 class AssessmentStepsSettingsSerializer(Serializer):
-    training = AssessmentStepSettingsSerializer(
+    studentTraining = AssessmentStepSettingsSerializer(
         step_name="student-training", source="rubric_assessments"
     )
     peer = AssessmentStepSettingsSerializer(
@@ -181,7 +183,10 @@ class AssessmentStepsSerializer(Serializer):
     settings = AssessmentStepsSettingsSerializer(source="*")
 
     def get_order(self, block):
-        return [step["name"] for step in block.rubric_assessments]
+        return [
+            STEP_NAME_MAPPINGS[WorkflowStep(step["name"]).workflow_step_name]
+            for step in block.rubric_assessments
+        ]
 
 
 class LeaderboardConfigSerializer(Serializer):

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -301,9 +301,7 @@ class PageDataSerializer(Serializer):
             # If the student is trying to jump to a step, verify they can
             jump_to_step = self.context.get("jump_to_step")
             workflow_step = self.context["step"]
-            if jump_to_step and not self._can_jump_to_step(
-                workflow_step, instance.workflow_data, jump_to_step
-            ):
+            if jump_to_step and not self._can_jump_to_step(workflow_step, instance.workflow_data, jump_to_step):
                 raise Exception(f"Can't jump to {jump_to_step} step before completion")
 
             # Go to the current step, or jump to the selected step

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -164,8 +164,6 @@ class SelfStepInfoSerializer(StepInfoBaseSerializer):
     }
     """
 
-    pass
-
 
 class StepInfoSerializer(Serializer):
     """

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -15,22 +15,12 @@ from rest_framework.serializers import (
 from openassessment.xblock.ui_mixins.mfe.assessment_serializers import (
     AssessmentResponseSerializer,
 )
+from openassessment.xblock.ui_mixins.mfe.serializer_utils import STEP_NAME_MAPPINGS
 from openassessment.xblock.ui_mixins.mfe.submission_serializers import (
     SubmissionSerializer,
 )
 
 from .ora_config_serializer import RubricConfigSerializer
-
-STEP_NAME_SERIALIZATION = {
-    "submission": "submission",
-    "peer": "peer",
-    "training": "studentTraining",
-    "self": "self",
-    "staff": "staff",
-    "ai": "ai",
-    "waiting": "waiting",
-    "done": "done",
-}
 
 
 class AssessmentScoreSerializer(Serializer):
@@ -242,7 +232,7 @@ class ProgressSerializer(Serializer):
         if not instance.workflow_data.has_workflow:
             return "submission"
         else:
-            return STEP_NAME_SERIALIZATION[instance.workflow_data.status]
+            return STEP_NAME_MAPPINGS[instance.workflow_data.status]
 
 
 class PageDataSerializer(Serializer):

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -238,7 +238,7 @@ class ProgressSerializer(Serializer):
     stepInfo = StepInfoSerializer(source="*")
 
     def get_activeStepName(self, instance):
-        """Return the active step name: one of 'submission"""
+        """Return the active step name"""
         if not instance.workflow_data.has_workflow:
             return "submission"
         else:

--- a/openassessment/xblock/ui_mixins/mfe/serializer_utils.py
+++ b/openassessment/xblock/ui_mixins/mfe/serializer_utils.py
@@ -4,6 +4,18 @@ Some custom serializer types and utils we use across our MFE
 
 from rest_framework.fields import BooleanField, CharField, ListField
 
+# Map workflow step name to serialized values
+STEP_NAME_MAPPINGS = {
+    "submission": "submission",
+    "peer": "peer",
+    "training": "studentTraining",
+    "self": "self",
+    "staff": "staff",
+    "ai": "ai",
+    "waiting": "waiting",
+    "done": "done",
+}
+
 
 class CharListField(ListField):
     """

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -3,6 +3,12 @@ Tests for PageDataSerializer
 """
 from copy import deepcopy
 
+from json import dumps, loads
+from unittest.mock import patch
+
+
+from openassessment.assessment.api import student_training
+from openassessment.assessment.test.constants import RUBRIC, EXAMPLES
 from openassessment.xblock.test.base import (
     PEER_ASSESSMENTS,
     SELF_ASSESSMENT,
@@ -10,9 +16,38 @@ from openassessment.xblock.test.base import (
     XBlockHandlerTestCase,
     scenario,
 )
-from openassessment.xblock.ui_mixins.mfe.page_context_serializer import (
-    PageDataSerializer,
-)
+from openassessment.xblock.ui_mixins.mfe.page_context_serializer import PageDataSerializer, ProgressSerializer
+
+
+class TestPageContextSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixin):
+    @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.AssessmentResponseSerializer")
+    @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.SubmissionSerializer")
+    @scenario("data/basic_scenario.xml", user_id="Alan")
+    def test_submission_view(self, xblock, mock_submission_serializer, mock_assessment_serializer):
+        # Given we are asking for the submission view
+        context = {"view": "submission"}
+
+        # When I ask for my submission data
+        PageDataSerializer(xblock, context=context).data
+
+        # Then I use the correct serializer and the call doesn't fail
+        mock_submission_serializer.assert_called_once()
+        mock_assessment_serializer.assert_not_called()
+
+    @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.AssessmentResponseSerializer")
+    @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.SubmissionSerializer")
+    @scenario("data/basic_scenario.xml", user_id="Alan")
+    def test_assessment_view(self, xblock, mock_submission_serializer, mock_assessment_serializer):
+        # Given we are asking for the assessment view
+        self.create_test_submission(xblock)
+        context = {"view": "assessment"}
+
+        # When I ask for assessment data
+        PageDataSerializer(xblock, context=context).data
+
+        # Then I use the correct serializer and the call doesn't fail
+        mock_assessment_serializer.assert_called_once()
+        mock_submission_serializer.assert_not_called()
 
 
 class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsMixin):
@@ -39,9 +74,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         self.create_test_submission(xblock)
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data[
-            "submission"
-        ]
+        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
 
         # I get the appropriate response
         expected_response = {
@@ -73,14 +106,10 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # ... and that I have submitted and am on the peer grading step
         student_item = xblock.get_student_item_dict()
         text_responses = ["Answer A", "Answer B"]
-        self.create_test_submission(
-            xblock, student_item=student_item, submission_text=text_responses
-        )
+        self.create_test_submission(xblock, student_item=student_item, submission_text=text_responses)
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data[
-            "submission"
-        ]
+        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
 
         # I get the appropriate response
         expected_response = {
@@ -103,9 +132,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # ... but with no responses to assess
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data[
-            "submission"
-        ]
+        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
 
         # I get the appropriate response
         expected_response = {}
@@ -123,9 +150,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         self.create_test_submission(xblock)
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data[
-            "submission"
-        ]
+        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
 
         # Then I get an empty object
         expected_response = {}
@@ -137,9 +162,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         self.create_test_submission(xblock)
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data[
-            "submission"
-        ]
+        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
 
         # Then I get an empty object
         expected_response = {}
@@ -148,13 +171,9 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
     @scenario("data/self_assessment_scenario.xml", user_id="Alan")
     def test_done_response(self, xblock):
         # Given I'm on the done step
-        self.create_submission_and_assessments(
-            xblock, self.SUBMISSION, [], [], SELF_ASSESSMENT
-        )
+        self.create_submission_and_assessments(xblock, self.SUBMISSION, [], [], SELF_ASSESSMENT)
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data[
-            "submission"
-        ]
+        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
 
         # Then I get an empty object
         expected_response = {}
@@ -213,3 +232,255 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # Then I expect the serializer to raise an exception
         with self.assertRaises(Exception):
             _ = PageDataSerializer(xblock, context=self.context).data
+
+
+class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
+    # Show full dict diffs
+    maxDiff = None
+
+    def assertNestedDictEquals(self, dict_1, dict_2):
+        # Manually expand nested dicts for comparison
+        dict_1_expanded = loads(dumps(dict_1))
+        dict_2_expanded = loads(dumps(dict_2))
+        return self.assertDictEqual(dict_1_expanded, dict_2_expanded)
+
+    @scenario("data/basic_scenario.xml", user_id="Alan")
+    def test_submission(self, xblock):
+        # Given I am on the submission step
+
+        # When I ask for progress
+        context = {"step": "submission"}
+        progress_data = ProgressSerializer(xblock, context=context).data
+
+        # Then I get the expected shapes
+        expected_data = {
+            "activeStepName": "submission",
+            "hasReceivedFinalGrade": False,
+            "receivedGrades": {},
+            "stepInfo": {"peer": None, "self": None},
+        }
+
+        self.assertNestedDictEquals(expected_data, progress_data)
+
+    @scenario("data/student_training.xml", user_id="Alan")
+    def test_student_training(self, xblock):
+        # Given I am on the student training step
+        self.create_test_submission(xblock)
+
+        # When I ask for progress
+        context = {"step": "training"}
+        progress_data = ProgressSerializer(xblock, context=context).data
+
+        # Then I get the expected shapes
+        expected_data = {
+            "activeStepName": "studentTraining",
+            "hasReceivedFinalGrade": False,
+            "receivedGrades": {
+                "peer": {},
+                "staff": {},
+            },
+            "stepInfo": {
+                "studentTraining": {
+                    "closed": False,
+                    "closedReason": None,
+                    "numberOfAssessmentsCompleted": 0,
+                    "expectedRubricSelections": [
+                        {
+                            "name": "Vocabulary",
+                            "selection": "Good",
+                        },
+                        {"name": "Grammar", "selection": "Excellent"},
+                    ],
+                },
+                "peer": None,
+            },
+        }
+
+        self.assertNestedDictEquals(expected_data, progress_data)
+
+    @scenario("data/student_training_due.xml", user_id="Alan")
+    def test_student_training_due(self, xblock):
+        # Given I am on the student training step, but it is past due
+        self.create_test_submission(xblock)
+
+        # When I ask for progress
+        context = {"step": "training"}
+        progress_data = ProgressSerializer(xblock, context=context).data
+
+        # Then I get the expected shapes
+        expected_data = {
+            "activeStepName": "studentTraining",
+            "hasReceivedFinalGrade": False,
+            "receivedGrades": {
+                "peer": {},
+                "staff": {},
+            },
+            "stepInfo": {
+                "studentTraining": {
+                    "closed": True,
+                    "closedReason": "pastDue",
+                    "numberOfAssessmentsCompleted": 0,
+                    "expectedRubricSelections": [
+                        {
+                            "name": "Vocabulary",
+                            "selection": "Good",
+                        },
+                        {"name": "Grammar", "selection": "Excellent"},
+                    ],
+                },
+                "peer": None,
+            },
+        }
+
+        self.assertNestedDictEquals(expected_data, progress_data)
+
+    @scenario("data/student_training_future.xml", user_id="Alan")
+    def test_student_training_not_yet_available(self, xblock):
+        # Given I am on the student training step, but it is past due
+        self.create_test_submission(xblock)
+
+        # When I ask for progress
+        context = {"step": "training"}
+        progress_data = ProgressSerializer(xblock, context=context).data
+
+        # Then I get the expected shapes
+        expected_data = {
+            "activeStepName": "studentTraining",
+            "hasReceivedFinalGrade": False,
+            "receivedGrades": {
+                "peer": {},
+                "staff": {},
+            },
+            "stepInfo": {
+                "studentTraining": {
+                    "closed": True,
+                    "closedReason": "notAvailableYet",
+                    "numberOfAssessmentsCompleted": 0,
+                    "expectedRubricSelections": [
+                        {
+                            "name": "Vocabulary",
+                            "selection": "Good",
+                        },
+                        {"name": "Grammar", "selection": "Excellent"},
+                    ],
+                },
+                "peer": None,
+            },
+        }
+
+        self.assertNestedDictEquals(expected_data, progress_data)
+
+    @scenario("data/peer_only_scenario.xml", user_id="Alan")
+    def test_peer_assessment(self, xblock):
+        # Given I am on the peer step
+        self.create_test_submission(xblock)
+
+        # When I ask for progress
+        context = {"step": "peer"}
+        progress_data = ProgressSerializer(xblock, context=context).data
+
+        # Then I get the expected shapes
+        expected_data = {
+            "activeStepName": "peer",
+            "hasReceivedFinalGrade": False,
+            "receivedGrades": {
+                "peer": {},
+                "staff": {},
+            },
+            "stepInfo": {
+                "peer": {
+                    "closed": False,
+                    "closedReason": None,
+                    "numberOfAssessmentsCompleted": 0,
+                    "isWaitingForSubmissions": True,
+                    "numberOfReceivedAssessments": 0,
+                }
+            },
+        }
+
+        self.assertNestedDictEquals(expected_data, progress_data)
+
+    @scenario("data/self_only_scenario.xml", user_id="Alan")
+    def test_self_assessment(self, xblock):
+        # Given I am on the self step
+        self.create_test_submission(xblock)
+
+        # When I ask for progress
+        context = {"step": "self"}
+        progress_data = ProgressSerializer(xblock, context=context).data
+
+        # Then I get the expected shapes
+        expected_data = {
+            "activeStepName": "self",
+            "hasReceivedFinalGrade": False,
+            "receivedGrades": {
+                "self": {},
+                "staff": {},
+            },
+            "stepInfo": {
+                "self": {
+                    "closed": False,
+                    "closedReason": None,
+                }
+            },
+        }
+
+        self.assertNestedDictEquals(expected_data, progress_data)
+
+    @scenario("data/self_assessment_closed.xml", user_id="Alan")
+    def test_self_assessment_closed(self, xblock):
+        # Given I am on the self step, but it is closed
+        self.create_test_submission(xblock)
+
+        # When I ask for progress
+        context = {"step": "self"}
+        progress_data = ProgressSerializer(xblock, context=context).data
+
+        # Then I get the expected shapes
+        expected_data = {
+            "activeStepName": "self",
+            "hasReceivedFinalGrade": False,
+            "receivedGrades": {
+                "self": {},
+                "peer": {},
+                "staff": {},
+            },
+            "stepInfo": {
+                "peer": None,
+                "self": {
+                    "closed": True,
+                    "closedReason": "pastDue",
+                },
+            },
+        }
+
+        self.assertNestedDictEquals(expected_data, progress_data)
+
+    @scenario("data/self_assessment_unavailable.xml", user_id="Alan")
+    def test_self_assessment_not_available(self, xblock):
+        # Given I am on the self step, but it is closed
+        self.create_test_submission(xblock)
+
+        # When I ask for progress
+        context = {"step": "self"}
+        progress_data = ProgressSerializer(xblock, context=context).data
+
+        # Then I get the expected shapes
+        expected_data = {
+            "activeStepName": "self",
+            "hasReceivedFinalGrade": False,
+            "receivedGrades": {
+                "self": {},
+                "peer": {},
+                "staff": {},
+            },
+            "stepInfo": {
+                "peer": None,
+                "self": {
+                    "closed": True,
+                    "closedReason": "notAvailableYet",
+                },
+            },
+        }
+
+        self.assertNestedDictEquals(expected_data, progress_data)

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -7,8 +7,6 @@ from json import dumps, loads
 from unittest.mock import patch
 
 
-from openassessment.assessment.api import student_training
-from openassessment.assessment.test.constants import RUBRIC, EXAMPLES
 from openassessment.xblock.test.base import (
     PEER_ASSESSMENTS,
     SELF_ASSESSMENT,
@@ -28,7 +26,7 @@ class TestPageContextSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         context = {"view": "submission"}
 
         # When I ask for my submission data
-        PageDataSerializer(xblock, context=context).data
+        _ = PageDataSerializer(xblock, context=context).data
 
         # Then I use the correct serializer and the call doesn't fail
         mock_submission_serializer.assert_called_once()
@@ -43,7 +41,7 @@ class TestPageContextSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         context = {"view": "assessment"}
 
         # When I ask for assessment data
-        PageDataSerializer(xblock, context=context).data
+        _ = PageDataSerializer(xblock, context=context).data
 
         # Then I use the correct serializer and the call doesn't fail
         mock_assessment_serializer.assert_called_once()

--- a/openassessment/xblock/ui_mixins/mfe/test_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_serializers.py
@@ -263,8 +263,8 @@ class TestAssessmentStepsSerializer(XBlockHandlerTestCase):
     @scenario("data/basic_scenario.xml")
     def test_order(self, xblock):
         # Given a basic setup
-        expected_order = ["peer-assessment", "self-assessment"]
-        expected_step_keys = {"training", "peer", "self", "staff"}
+        expected_order = ["peer", "self"]
+        expected_step_keys = {"studentTraining", "peer", "self", "staff"}
 
         # When I ask for assessment step config
         steps_config = AssessmentStepsSerializer(xblock).data
@@ -328,7 +328,7 @@ class TestTrainingSettingsSerializer(XBlockHandlerTestCase):
     Test for TrainingSettingsSerializer
     """
 
-    step_config_key = "training"
+    step_config_key = "studentTraining"
 
     @scenario("data/student_training.xml")
     def test_enabled(self, xblock):


### PR DESCRIPTION
**TL;DR -** Update backend to align with contract changes RE `StepInfo`

JIRA: [AU-1480](https://2u-internal.atlassian.net/browse/AU-1480)

**What changed?**

- Change `activeStepInfo` to `stepInfo`
- Update sub-steps to include `closed` and `closedReason`
- Add some missing `PageContextSerializer` tests
- Add some utils for mapping and comparing workflow steps and progress

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled

**Testing Instructions**

- [ ] Unit tests.
- Exercise the following endpoints:
    - [ ] `get_block_learner_assessment_data`
    - [ ] `get_block_learner_submission_data` 

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
