### PR TITLE
 feat: add extra fields to ORA staff graded serializer

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -95,6 +95,48 @@ def map_anonymized_ids_to_usernames(anonymized_ids):
 
     return anonymous_id_to_username_mapping
 
+def map_anonymized_ids_to_emails(anonymized_ids):
+    """
+    Args:
+        anonymized_ids - list of anonymized user ids.
+    Returns:
+        dictionary, that contains mapping between anonymized user ids and
+        actual user emails.
+    """
+    User = get_user_model()
+
+    users = _use_read_replica(
+        User.objects.filter(anonymoususerid__anonymous_user_id__in=anonymized_ids)
+        .annotate(anonymous_id=F("anonymoususerid__anonymous_user_id"))
+        .values("email", "anonymous_id")
+    )
+    anonymous_id_to_email_mapping = {
+        user["anonymous_id"]: user["email"] for user in users
+    }
+    return anonymous_id_to_email_mapping
+
+
+def map_anonymized_ids_to_fullname(anonymized_ids):
+    """
+    Args:
+        anonymized_ids - list of anonymized user ids.
+    Returns:
+        dictionary, that contains mapping between anonymized user ids and
+        actual user fullname.
+    """
+    User = get_user_model()
+
+    users = _use_read_replica(
+        User.objects.filter(anonymoususerid__anonymous_user_id__in=anonymized_ids)
+        .select_related("profile")
+        .annotate(anonymous_id=F("anonymoususerid__anonymous_user_id"))
+        .values("profile__name", "anonymous_id")
+    )
+
+    anonymous_id_to_fullname_mapping = {
+        user["anonymous_id"]: user["profile__name"] for user in users
+    }
+    return anonymous_id_to_fullname_mapping
 
 class CsvWriter:
     """


### PR DESCRIPTION
## feat: endpoint `/api/ora_staff_grader/initialize` upgraded
![Peek 2023-10-13 20-47](https://github.com/eduNEXT/edx-ora2/assets/12719909/55560bdf-8e42-47db-bcd0-71c0c9c3dac8)

### Implementation Details
This PR adds the `fullname` and `email` fields to the `/api/ora_staff_grader/initialize` endpoint.
Modifications were made in the following directories:

#### ORA2

- openassessment/staffgrader/serializers/submission_list.py
- openassessment/staffgrader/staff_grader_mixin.py
- openassessment/data.py

#### edx-platform

- lms/djangoapps/ora_staff_grader/serializers.py


This upgrade will consist of two PRs: one for ORA and the other for edx-platform. This is because the main serializer of the service resides in the platform. To test it, you'll need to fetch and set up the version of the platform with the serializer modification.

- **Platform PR link**: https://github.com/openedx/edx-platform/pull/33507