### PR TITLE
feat: updated blocked submission lookup query (batch update)

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '5.5.5'
+__version__ = '5.5.6'

--- a/openassessment/workflow/test/test_workflow_batch_update_api.py
+++ b/openassessment/workflow/test/test_workflow_batch_update_api.py
@@ -31,6 +31,7 @@ class TestWorkflowBatchUpdateAPI(CacheResetTest):
         _tim_sub, _tim = self._create_student_and_submission("Tim", "Tim's answer")
         self._create_student_and_submission("Miles", "Miles's answer")
         _pat_sub, _pat = self._create_student_and_submission("Pat", "Pat's answer")
+        _wayne_sub, _wayne = self._create_student_and_submission("Wayne", "Wayne's answer")
 
         blocked = update_api.get_blocked_peer_workflows()
         # we expect 0 blocked submissions as they were just created
@@ -42,8 +43,14 @@ class TestWorkflowBatchUpdateAPI(CacheResetTest):
         pw_tim.created_at = timezone.now() - datetime.timedelta(days=8)
         pw_tim.completed_at = timezone.now() - datetime.timedelta(days=3)
         pw_tim.save()
+        # set Wayne's submission as cancelled
+        pw_wayne = PeerWorkflow.objects.get(student_id=_wayne["student_id"])
+        pw_wayne.created_at = timezone.now() - datetime.timedelta(days=8)
+        pw_wayne.completed_at = timezone.now() - datetime.timedelta(days=3)
+        pw_wayne.cancelled_at = timezone.now() - datetime.timedelta(days=3)
+        pw_wayne.save()
         blocked = update_api.get_blocked_peer_workflows()
-        # we expect 1 blocked submission
+        # we expect 1 blocked submission (Tim's)
         self.assertEqual(len(blocked), 1)
 
         # set Pat's submission create_at date to >7 days ago and set completed_at date

--- a/openassessment/workflow/workflow_batch_update_api.py
+++ b/openassessment/workflow/workflow_batch_update_api.py
@@ -267,7 +267,8 @@ def get_blocked_peer_workflows(course_id=None, item_id=None, submission_uuid=Non
     filters = {
         'created_at__lte': timezone.now() - datetime.timedelta(days=7),
         'grading_completed_at__isnull': True,
-        'completed_at__isnull': False
+        'completed_at__isnull': False,
+        'cancelled_at__isnull': True
     }
     if course_id is not None:
         filters['course_id'] = course_id

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** 

Enhanced lookup query to filter out cancelled submissions. 

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

After 5am (UTC) execution,  result of this Splunk query should not include cancelled submissions:
```
index="prod-edx" "service_variant=lms" "openassessment.workflow.workflow_batch_update_api" "function_name=update_workflow_for_submission" "openassessment.workflow.workflow_batch_update_api" "*ORA workflow update for a single blocked submission completed successfully"| table  submission_uuid
```


**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
