### PR TITLE
refactor: BFF contract updates (round 2)

### DIFF
--- a/openassessment/xblock/apis/step_data_api.py
+++ b/openassessment/xblock/apis/step_data_api.py
@@ -34,6 +34,8 @@ class StepDataAPI:
     @property
     def has_reached_step(self):
         """Util for determining if we have reached or surpassed this step"""
+        if self._step == "submission":
+            return True
         if self.workflow_data.status == self._step:
             return True
         step_info = self.workflow_data.status_details.get(str(self._step), {})

--- a/openassessment/xblock/apis/submissions/submissions_api.py
+++ b/openassessment/xblock/apis/submissions/submissions_api.py
@@ -38,7 +38,7 @@ class SubmissionAPI(StepDataAPI):
 
     @property
     def has_been_cancelled(self):
-        return self.workflow and self.workflow["status"] == "cancelled"
+        return bool(self.workflow) and self.workflow["status"] == "cancelled"
 
     @property
     def cancellation_info(self):

--- a/openassessment/xblock/apis/submissions/submissions_api.py
+++ b/openassessment/xblock/apis/submissions/submissions_api.py
@@ -178,6 +178,9 @@ class SubmissionAPI(StepDataAPI):
         return self.workflow.get("team_submission_uuid")
 
     def get_submission_team_info(self, workflow):
+        """
+        Returns tuple (team info, team ID)
+        """
         if not self.is_team_assignment:
             return {}, None
 

--- a/openassessment/xblock/apis/submissions/submissions_api.py
+++ b/openassessment/xblock/apis/submissions/submissions_api.py
@@ -196,7 +196,7 @@ class SubmissionAPI(StepDataAPI):
             # for shared files lookup. If the learner has submitted already for a different team
             # and then joined another team, we should show the submission that they are actually a part of,
             # rather than just their current team. If they have a submission (and therefore a workflow) then
-            # that takes precidence.
+            # that takes precedence.
             team_submission = get_team_submission(workflow['team_submission_uuid'])
             team_id = team_submission['team_id']
         return team_info, team_id

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -83,7 +83,7 @@ class WorkflowAPI:
         return self.workflow.get("status")
 
     @property
-    def has_recieved_grade(self):
+    def has_received_grade(self):
         return bool(self.workflow.get('score'))
 
     def get_workflow_status_counts(self):

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -261,7 +261,7 @@ class MfeMixin:
             'workflow': {
                 'has_submitted': self.submission_data.has_submitted,
                 'has_cancelled': self.workflow_data.is_cancelled,
-                'has_recieved_grade': self.workflow_data.has_recieved_grade,
+                'has_received_grade': self.workflow_data.has_received_grade,
             },
             'team_info': team_info,
             'response': response,

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -76,7 +76,7 @@ class MfeMixin:
         # Determine which mode we are viewing in, since data comes from different sources
         if workflow_step or jump_step == "submission":
             has_submitted = self.workflow_data.has_submitted
-            
+
             # View our submitted response
             if has_submitted:
                 serializer_context.update({"view": "submission"})
@@ -84,7 +84,7 @@ class MfeMixin:
             # View our draft response
             else:
                 serializer_context.update({"view": "draft"})
-        
+
         # View the selected assessment step
         else:
             serializer_context.update({"view": "assessment"})

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -242,9 +242,11 @@ class MfeMixin:
         return self.submission_data.files.file_manager.team_file_descriptors(team_id=team_id)
 
     def get_learner_submission_data(self):
+        # TODO - Move this out of mixin, this is only here because it accesses
+        # private functions in the mixin but should actually be in SubmissionAPI
         workflow = self.get_team_workflow_info() if self.is_team_assignment() else self.get_workflow_info()
         team_info, team_id = self.submission_data.get_submission_team_info(workflow)
-        # If there is a submission, we do not need to load file upload data seprately because files
+        # If there is a submission, we do not need to load file upload data separately because files
         # will already have been gathered into the submission. If there is no submission, we need to
         # load file data from learner state and the SharedUpload db model
         if self.submission_data.has_submitted:

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -48,24 +48,65 @@ class MfeMixin:
         return block_info.data
 
     @XBlock.json_handler
-    def get_block_learner_submission_data(self, data, suffix=""):  # pylint: disable=unused-argument
-        serializer_context = {"view": "submission"}
-        page_context = PageDataSerializer(self, context=serializer_context)
-        return page_context.data
-
-    @XBlock.json_handler
-    def get_block_learner_assessment_data(self, data, suffix=""):  # pylint: disable=unused-argument
-        serializer_context = {"view": "assessment", "step": suffix}
+    def get_learner_data(self, data, suffix=""):  # pylint: disable=unused-argument
+        """
+        Get data for the user / step of the ORA
+        - If no step provided, go to current workflow step
+            - If not submitted, load draft submission
+            - If submitted, load fir
+        - If user provides jumpable step
+            - Check if we can get to that step
+            - If we can, go to that step
+            - Otherwise, raise an error
+        """
+        workflow_step = self.workflow_data.status or "submission"
+        jump_step = suffix
+        serializer_context = {"step": workflow_step}
 
         # Allow jumping to a specific step, within our allowed steps
-        # NOTE should probably also verify this step is in our assessment steps
-        # though the serializer also covers for this currently
-        jumpable_steps = "peer"
-        if suffix in jumpable_steps:
-            serializer_context.update({"jump_to_step": suffix})
+        if jump_step:
+            jumpable_steps = ("submission", "peer", "grades")
+            if jump_step not in jumpable_steps:
+                return JsonHandlerError(404, f"Invalid jump to step: {jump_step}")
+            if self._can_jump_to_step(workflow_step, jump_step):
+                serializer_context.update({"jump_to_step": suffix})
+            else:
+                return JsonHandlerError(400, f"Cannot jump to step: {jump_step}")
+
+        # Determine which mode we are viewing in, since data comes from different sources
+        if workflow_step or jump_step == "submission":
+            has_submitted = self.workflow_data.has_submitted
+            
+            # View our submitted response
+            if has_submitted:
+                serializer_context.update({"view": "submission"})
+
+            # View our draft response
+            else:
+                serializer_context.update({"view": "draft"})
+        
+        # View the selected assessment step
+        else:
+            serializer_context.update({"view": "assessment"})
 
         page_context = PageDataSerializer(self, context=serializer_context)
         return page_context.data
+
+    def _can_jump_to_step(self, workflow_step, jump_step):
+        """ A helper to determine if we can jump to a step or not """
+
+        if jump_step == workflow_step:
+            return True
+
+        jump_step_to_workflow_step = {
+            "submission": "submission",
+            "peer": "peer",
+            "grades": "done"
+        }
+        jump_step_name = jump_step_to_workflow_step[jump_step]
+
+        step_status = self.workflow_data.status_details.get(jump_step_name, {})
+        return step_status.get("complete", False)
 
     def _submission_draft_handler(self, data):
         try:

--- a/openassessment/xblock/ui_mixins/mfe/ora_config_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/ora_config_serializer.py
@@ -113,15 +113,15 @@ class RubricConfigSerializer(Serializer):
 class SelfSettingsSerializer(Serializer):
     required = BooleanField(default=True)
 
-    startTime = DateTimeField(source="start")
-    endTime = DateTimeField(source="due")
+    startDatetime = DateTimeField(source="start")
+    endDatetime = DateTimeField(source="due")
 
 
 class PeerSettingsSerializer(Serializer):
     required = BooleanField(default=True)
 
-    startTime = DateTimeField(source="start")
-    endTime = DateTimeField(source="due")
+    startDatetime = DateTimeField(source="start")
+    endDatetime = DateTimeField(source="due")
 
     minNumberToGrade = IntegerField(source="must_grade")
     minNumberToBeGradedBy = IntegerField(source="must_be_graded_by")

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -16,7 +16,7 @@ from openassessment.xblock.ui_mixins.mfe.assessment_serializers import (
     AssessmentGradeSerializer,
     AssessmentResponseSerializer,
 )
-from openassessment.xblock.ui_mixins.mfe.submission_serializers import PageDataSubmissionSerializer
+from openassessment.xblock.ui_mixins.mfe.submission_serializers import DraftResponseSerializer, SubmissionSerializer
 from openassessment.xblock.ui_mixins.mfe.serializer_utils import STEP_NAME_MAPPINGS, CharListField
 
 
@@ -324,7 +324,13 @@ class PageDataSerializer(Serializer):
         # Submission Views
         if self.context.get("view") == "submission":
             learner_page_data_submission_data = instance.get_learner_submission_data()
-            return PageDataSubmissionSerializer(learner_page_data_submission_data).data
+
+            # Draft response
+            if not instance.submission_data.has_submitted:
+                return DraftResponseSerializer(learner_page_data_submission_data).data
+
+            # Submitted response
+            return SubmissionSerializer(learner_page_data_submission_data).data
 
         # Assessment Views
         elif self.context.get("view") == "assessment":

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -146,9 +146,6 @@ class SubmissionStepInfoSerializer(ClosedInfoSerializer):
 
     teamInfo = SerializerMethodField()
 
-    def to_representation(self, instance):
-        return super().to_representation(instance)
-
     def get_teamInfo(self, instance):
         if not instance.is_team_assignment:
             return {}
@@ -310,9 +307,9 @@ class PageDataSerializer(Serializer):
 
     def to_representation(self, instance):
         if "step" not in self.context:
-            raise ValidationError(f"Missing required context: step")
+            raise ValidationError("Missing required context: step")
         if "view" not in self.context:
-            raise ValidationError(f"Missing required context: view")
+            raise ValidationError("Missing required context: view")
 
         return super().to_representation(instance)
 

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -18,8 +18,6 @@ from openassessment.xblock.ui_mixins.mfe.assessment_serializers import (
 from openassessment.xblock.ui_mixins.mfe.submission_serializers import PageDataSubmissionSerializer
 from openassessment.xblock.ui_mixins.mfe.serializer_utils import STEP_NAME_MAPPINGS
 
-from .ora_config_serializer import RubricConfigSerializer
-
 
 class AssessmentScoreSerializer(Serializer):
     """
@@ -241,7 +239,6 @@ class PageDataSerializer(Serializer):
 
     progress = ProgressSerializer(source="*")
     submission = SerializerMethodField()
-    rubric = RubricConfigSerializer(source="*")
     assessment = SerializerMethodField()
 
     def to_representation(self, instance):

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -47,7 +47,6 @@ class ReceivedGradesSerializer(Serializer):
     self = AssessmentScoreSerializer(source="grades.self_score")
     peer = AssessmentScoreSerializer(source="grades.peer_score")
     staff = AssessmentScoreSerializer(source="grades.staff_score")
-    # teams = AssessmentGradeSerializer(source="grades.teams_score")
 
     def to_representation(self, instance):
         """

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -95,6 +95,19 @@ class StepInfoBaseSerializer(ClosedInfoSerializer):
         return super().to_representation(instance)
 
 
+class SubmissionStepInfoSerializer(ClosedInfoSerializer):
+    """
+    Returns:
+        {
+            hasSubmitted: (Bool, Null for Assessment)
+            hasCancelled: (Bool, Null for Assessment)
+        }
+    """
+
+    hasSubmitted = BooleanField(source="has_submitted")
+    hasCancelled = BooleanField(source="has_been_cancelled", default=False)
+
+
 class StudentTrainingStepInfoSerializer(StepInfoBaseSerializer):
     """
     Returns:
@@ -172,6 +185,7 @@ class StepInfoSerializer(Serializer):
 
     require_context = True
 
+    submission = SubmissionStepInfoSerializer(source="submission_data")
     studentTraining = StudentTrainingStepInfoSerializer(source="student_training_data")
     peer = PeerStepInfoSerializer(source="peer_assessment_data")
     _self = SelfStepInfoSerializer(source="self_data")
@@ -207,7 +221,7 @@ class ProgressSerializer(Serializer):
     Returns:
     {
         // What step are we on? An index to the configuration from ORA config call.
-        activeStepName: (String) one of ["studentTraining", "peer", "self", "staff"]
+        activeStepName: (String) one of ["submission", "studentTraining", "peer", "self", "staff", "done]
 
         hasReceivedFinalGrade: (Bool) // In effect, is the ORA complete?
         receivedGrades: (Object) Staff grade data, when there is a completed staff grade.

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -156,6 +156,7 @@ class SubmissionStepInfoSerializer(ClosedInfoSerializer):
 
         return TeamInfoSerializer(team_info).data
 
+
 class StudentTrainingStepInfoSerializer(StepInfoBaseSerializer):
     """
     Returns:
@@ -308,9 +309,9 @@ class PageDataSerializer(Serializer):
     assessment = SerializerMethodField()
 
     def to_representation(self, instance):
-        if not "step" in self.context:
+        if "step" not in self.context:
             raise ValidationError(f"Missing required context: step")
-        if not "view" in self.context:
+        if "view" not in self.context:
             raise ValidationError(f"Missing required context: view")
 
         return super().to_representation(instance)

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -252,7 +252,7 @@ class PageDataSerializer(Serializer):
     require_context = True
 
     progress = ProgressSerializer(source="*")
-    submission = SerializerMethodField()
+    response = SerializerMethodField()
     assessment = SerializerMethodField()
 
     def to_representation(self, instance):
@@ -278,7 +278,7 @@ class PageDataSerializer(Serializer):
         step_status = workflow_data.status_details.get(step_name, {})
         return step_status.get("complete", False)
 
-    def get_submission(self, instance):
+    def get_response(self, instance):
         """
         we get the user's draft / complete submission.
         """

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -183,7 +183,7 @@ class StepInfoSerializer(Serializer):
     * Empty dict for remaining steps
     """
 
-    require_context = True
+    requires_context = True
 
     submission = SubmissionStepInfoSerializer(source="submission_data")
     studentTraining = StudentTrainingStepInfoSerializer(source="student_training_data")
@@ -249,7 +249,7 @@ class PageDataSerializer(Serializer):
     Requires context to differentiate between Assessment and Submission views
     """
 
-    require_context = True
+    requires_context = True
 
     progress = ProgressSerializer(source="*")
     response = SerializerMethodField()

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -102,6 +102,8 @@ class SubmissionStepInfoSerializer(ClosedInfoSerializer):
         {
             hasSubmitted: (Bool, Null for Assessment)
             hasCancelled: (Bool, Null for Assessment)
+            closed: (Bool / Null for Assessment)
+            closedReason: (Enum/ Null if open), one of "notAvailable", "pastDue"
         }
     """
 
@@ -113,6 +115,8 @@ class StudentTrainingStepInfoSerializer(StepInfoBaseSerializer):
     """
     Returns:
         {
+            closed: (Bool)
+            closedReason: (Enum/ Null if open), one of "notAvailable", "pastDue"
             numberOfAssessmentsCompleted: (Int), progress through required assessments
             expectedRubricSelections: (List of rubric names and selections)
         }
@@ -153,6 +157,8 @@ class PeerStepInfoSerializer(StepInfoBaseSerializer):
     """
     Returns:
         {
+            closed: (Bool)
+            closedReason: (Enum/ Null if open), one of "notAvailable", "pastDue"
             numberOfAssessmentsCompleted: (Int) Progress through required assessments
             isWaitingForSubmissions: (Bool) We've run out of peers to grade, waiting for more submissions
             numberOfReceivedAssessments: (Int) How many assessments has this response received

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -321,14 +321,14 @@ class PageDataSerializer(Serializer):
 
         # Submission Views
         if self.context.get("view") == "submission":
-            learner_page_data_submission_data = instance.get_learner_submission_data()
+            learner_submission_data = instance.get_learner_submission_data()
 
             # Draft response
             if not instance.submission_data.has_submitted:
-                return DraftResponseSerializer(learner_page_data_submission_data).data
+                return DraftResponseSerializer(learner_submission_data).data
 
             # Submitted response
-            return SubmissionSerializer(learner_page_data_submission_data).data
+            return SubmissionSerializer(learner_submission_data).data
 
         # Assessment Views
         elif self.context.get("view") == "assessment":

--- a/openassessment/xblock/ui_mixins/mfe/serializer_utils.py
+++ b/openassessment/xblock/ui_mixins/mfe/serializer_utils.py
@@ -10,9 +10,10 @@ STEP_NAME_MAPPINGS = {
     "peer": "peer",
     "training": "studentTraining",
     "self": "self",
-    "staff": "staff",
+    "teams": "teams",
     "ai": "ai",
     "waiting": "waiting",
+    "staff": "staff",
     "done": "done",
 }
 

--- a/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
@@ -98,7 +98,6 @@ class PageDataSubmissionSerializer(Serializer):
     """
     hasSubmitted = BooleanField(source="workflow.has_submitted")
     hasCancelled = BooleanField(source="workflow.has_cancelled", default=False)
-    hasRecievedGrade = BooleanField(source="workflow.has_recieved_grade", default=False)
     teamInfo = TeamInfoSerializer(source="team_info")
     response = SerializerMethodField(source="*")
 

--- a/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
@@ -65,38 +65,10 @@ class InProgressResponseSerializer(Serializer):
         return result
 
 
-class TeamFileDescriptorSerializer(Serializer):
-    fileUrl = URLField(source='download_url')
-    fileDescription = CharField(source='description')
-    fileName = CharField(source='name')
-    fileSize = IntegerField(source='size')
-    uploadedBy = CharField(source="uploaded_by")
-
-
-class TeamInfoSerializer(Serializer):
-    teamName = CharField(source="team_name")
-    teamUsernames = CharListField(source="team_usernames")
-    previousTeamName = CharField(source="previous_team_name", allow_null=True)
-    hasSubmitted = BooleanField(source="has_submitted")
-    teamUploadedFiles = ListField(
-        source="team_uploaded_files",
-        allow_empty=True,
-        child=TeamFileDescriptorSerializer(),
-        required=False
-    )
-
-    def to_representation(self, instance):
-        # If there's no team name, there's no team info to show
-        if 'team_name' not in instance:
-            return {}
-        return super().to_representation(instance)
-
-
 class PageDataSubmissionSerializer(Serializer):
     """
     Main serializer for learner submission status / info
     """
-    teamInfo = TeamInfoSerializer(source="team_info")
     response = SerializerMethodField(source="*")
 
     def get_response(self, data):

--- a/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
@@ -49,7 +49,7 @@ class SubmissionSerializer(Serializer):
         for index, uploaded_file in enumerate(response.get_file_uploads(generate_urls=True)):
             result.append(SubmissionFileSerializer(({'file': uploaded_file, 'file_index': index})).data)
         return result
-    
+
     def to_representation(self, instance):
         # Unpack response.
         # This is to keep signature similar between the draft and submitted responses.

--- a/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
@@ -48,9 +48,23 @@ class FileDescriptorSerializer(Serializer):
     fileIndex = IntegerField(source="file_index")
 
 
+class TeamFileDescriptorSerializer(Serializer):
+    fileUrl = URLField(source='download_url')
+    fileDescription = CharField(source='description')
+    fileName = CharField(source='name')
+    fileSize = IntegerField(source='size')
+    uploadedBy = CharField(source="uploaded_by")
+
+
 class InProgressResponseSerializer(Serializer):
     textResponses = SerializerMethodField()
     uploadedFiles = SerializerMethodField()
+    teamUploadedFiles = ListField(
+        source="team_info.team_uploaded_files",
+        allow_empty=True,
+        child=TeamFileDescriptorSerializer(),
+        required=False
+    )
 
     def get_textResponses(self, data):
         return [

--- a/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
@@ -96,8 +96,6 @@ class PageDataSubmissionSerializer(Serializer):
     """
     Main serializer for learner submission status / info
     """
-    hasSubmitted = BooleanField(source="workflow.has_submitted")
-    hasCancelled = BooleanField(source="workflow.has_cancelled", default=False)
     teamInfo = TeamInfoSerializer(source="team_info")
     response = SerializerMethodField(source="*")
 

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -32,7 +32,7 @@ from openassessment.xblock.test.test_staff_area import NullUserService, UserStat
 from openassessment.xblock.test.test_submission import COURSE_ID, setup_mock_team
 from openassessment.xblock.test.test_team import MOCK_TEAM_ID, MockTeamsService
 from openassessment.xblock.ui_mixins.mfe.constants import error_codes, handler_suffixes
-from openassessment.xblock.ui_mixins.mfe.submission_serializers import PageDataSubmissionSerializer
+from openassessment.xblock.ui_mixins.mfe.submission_serializers import DraftResponseSerializer, SubmissionSerializer
 
 
 class MFEHandlersTestBase(XBlockHandlerTestCase):
@@ -146,6 +146,8 @@ def assert_called_once_with_helper(mock, expected_first_arg, expected_additional
 
 class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
 
+    maxDiff = None
+
     def setup_xblock(self, xblock):
         xblock.xmodule_runtime = Mock(
             user_is_staff=False,
@@ -158,13 +160,11 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
     def test_nothing(self, xblock):
         with self.mock_get_url():
             learner_submission_data = xblock.get_learner_submission_data()
-            data = PageDataSubmissionSerializer(learner_submission_data).data
+            data = DraftResponseSerializer(learner_submission_data).data
         assert data == {
-            'response': {
-                'textResponses': ['', ''],
-                'uploadedFiles': [],
-                'teamUploadedFiles': [],
-            }
+            'textResponses': ['', ''],
+            'uploadedFiles': [],
+            'teamUploadedFiles': [],
         }
 
     @scenario("data/file_upload_scenario.xml", user_id='r5')
@@ -178,32 +178,30 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
         student_item = xblock.get_student_item_dict()
         base_key = f'{student_item["student_id"]}/{student_item["course_id"]}/{student_item["item_id"]}'
         with self.mock_get_url({
-            base_key: 'www.example.xyz/0',
+            base_key: 'www.downloadfiles.xyz/0',
             base_key + '/1': 'www.downloadfiles.xyz/1'
         }):
             learner_submission_data = xblock.get_learner_submission_data()
-            data = PageDataSubmissionSerializer(learner_submission_data).data
+            data = DraftResponseSerializer(learner_submission_data).data
         assert data == {
-            'response': {
-                'textResponses': ['hello world', 'goodnight moon'],
-                'uploadedFiles': [
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/0',
-                        'fileName': 'file1.ppt',
-                        'fileDescription': 'my presentation',
-                        'fileSize': 2,
-                        'fileIndex': 0,
-                    },
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/1',
-                        'fileName': 'file3.mp4',
-                        'fileDescription': 'video of presentation',
-                        'fileSize': 3,
-                        'fileIndex': 1,
-                    },
-                ],
-                'teamUploadedFiles': [],
-            }
+            'textResponses': ['hello world', 'goodnight moon'],
+            'uploadedFiles': [
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/0',
+                    'fileName': 'file1.ppt',
+                    'fileDescription': 'my presentation',
+                    'fileSize': 2,
+                    'fileIndex': 0,
+                },
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/1',
+                    'fileName': 'file3.mp4',
+                    'fileDescription': 'video of presentation',
+                    'fileSize': 3,
+                    'fileIndex': 1,
+                },
+            ],
+            'teamUploadedFiles': [],
         }
 
     @scenario("data/file_upload_scenario.xml", user_id='r5')
@@ -225,27 +223,26 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
 
         with self.mock_get_url():
             learner_submission_data = xblock.get_learner_submission_data()
-            data = PageDataSubmissionSerializer(learner_submission_data).data
+            data = SubmissionSerializer(learner_submission_data).data
         assert data == {
-            'response': {
-                'textResponses': ['hello world', 'goodnight world'],
-                'uploadedFiles': [
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/f1',
-                        'fileName': 'f1.txt',
-                        'fileDescription': 'file1',
-                        'fileSize': 10,
-                        'fileIndex': 0,
-                    },
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/f2',
-                        'fileName': 'f2.pdf',
-                        'fileDescription': 'file2',
-                        'fileSize': 300,
-                        'fileIndex': 1,
-                    },
-                ]
-            }
+            'textResponses': ['hello world', 'goodnight world'],
+            'uploadedFiles': [
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/f1',
+                    'fileName': 'f1.txt',
+                    'fileDescription': 'file1',
+                    'fileSize': 10,
+                    'fileIndex': 0,
+                },
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/f2',
+                    'fileName': 'f2.pdf',
+                    'fileDescription': 'file2',
+                    'fileSize': 300,
+                    'fileIndex': 1,
+                },
+            ],
+            'teamUploadedFiles': None,
         }
 
 
@@ -265,13 +262,11 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
         self.setup_xblock(xblock)
         with self.mock_get_url():
             learner_submission_data = xblock.get_learner_submission_data()
-            data = PageDataSubmissionSerializer(learner_submission_data).data
+            data = DraftResponseSerializer(learner_submission_data).data
         assert data == {
-            'response': {
-                'textResponses': ['', ''],
-                'uploadedFiles': [],
-                'teamUploadedFiles': []
-            },
+            'textResponses': ['', ''],
+            'uploadedFiles': [],
+            'teamUploadedFiles': [],
         }
 
     @scenario("data/team_submission_file_scenario.xml", user_id='r5')
@@ -310,43 +305,41 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
             shared_file_2_key: 'www.downloadfiles.xyz/shared2',
         }):
             learner_submission_data = xblock.get_learner_submission_data()
-            data = PageDataSubmissionSerializer(learner_submission_data).data
+            data = DraftResponseSerializer(learner_submission_data).data
         assert data == {
-            'response': {
-                'textResponses': ['hello world', 'goodnight moon'],
-                'uploadedFiles': [
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/0',
-                        'fileName': 'file1.ppt',
-                        'fileDescription': 'my presentation',
-                        'fileSize': 2,
-                        'fileIndex': 0,
-                    },
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/1',
-                        'fileName': 'file3.mp4',
-                        'fileDescription': 'video of presentation',
-                        'fileSize': 3,
-                        'fileIndex': 1,
-                    },
-                ],
-                'teamUploadedFiles': [
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/shared1',
-                        'fileName': shared_file_1.name,
-                        'fileDescription': shared_file_1.description,
-                        'fileSize': shared_file_1.size,
-                        'uploadedBy': r1.username,
-                    },
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/shared2',
-                        'fileName': shared_file_2.name,
-                        'fileDescription': shared_file_2.description,
-                        'fileSize': shared_file_2.size,
-                        'uploadedBy': r2.username,
-                    },
-                ],
-            }
+            'textResponses': ['hello world', 'goodnight moon'],
+            'uploadedFiles': [
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/0',
+                    'fileName': 'file1.ppt',
+                    'fileDescription': 'my presentation',
+                    'fileSize': 2,
+                    'fileIndex': 0,
+                },
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/1',
+                    'fileName': 'file3.mp4',
+                    'fileDescription': 'video of presentation',
+                    'fileSize': 3,
+                    'fileIndex': 1,
+                },
+            ],
+            'teamUploadedFiles': [
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/shared1',
+                    'fileName': shared_file_1.name,
+                    'fileDescription': shared_file_1.description,
+                    'fileSize': shared_file_1.size,
+                    'uploadedBy': r1.username,
+                },
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/shared2',
+                    'fileName': shared_file_2.name,
+                    'fileDescription': shared_file_2.description,
+                    'fileSize': shared_file_2.size,
+                    'uploadedBy': r2.username,
+                },
+            ],
         }
 
     @scenario("data/team_submission_file_scenario.xml", user_id='r5')
@@ -369,34 +362,33 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
         )
         with self.mock_get_url():
             learner_submission_data = xblock.get_learner_submission_data()
-            data = PageDataSubmissionSerializer(learner_submission_data).data
+            data = SubmissionSerializer(learner_submission_data).data
         assert data == {
-            'response': {
-                'textResponses': ['This is the answer'],
-                'uploadedFiles': [
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/k1',
-                        'fileName': '1.txt',
-                        'fileDescription': '1',
-                        'fileSize': 12,
-                        'fileIndex': 0,
-                    },
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/k2',
-                        'fileName': '2.txt',
-                        'fileDescription': '2',
-                        'fileSize': 1,
-                        'fileIndex': 1,
-                    },
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/k3',
-                        'fileName': '3.txt',
-                        'fileDescription': '3',
-                        'fileSize': 56,
-                        'fileIndex': 2,
-                    },
-                ]
-            }
+            'textResponses': ['This is the answer'],
+            'uploadedFiles': [
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/k1',
+                    'fileName': '1.txt',
+                    'fileDescription': '1',
+                    'fileSize': 12,
+                    'fileIndex': 0,
+                },
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/k2',
+                    'fileName': '2.txt',
+                    'fileDescription': '2',
+                    'fileSize': 1,
+                    'fileIndex': 1,
+                },
+                {
+                    'fileUrl': 'www.downloadfiles.xyz/k3',
+                    'fileName': '3.txt',
+                    'fileDescription': '3',
+                    'fileSize': 56,
+                    'fileIndex': 2,
+                },
+            ],
+            'teamUploadedFiles': None,
         }
 
     def _create_team_submission_and_workflow(

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -160,10 +160,6 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
             learner_submission_data = xblock.get_learner_submission_data()
             data = PageDataSubmissionSerializer(learner_submission_data).data
         assert data == {
-            'hasSubmitted': False,
-            'hasCancelled': False,
-            'hasRecievedGrade': False,
-            'teamInfo': {},
             'response': {
                 'textResponses': ['', ''],
                 'uploadedFiles': []
@@ -187,10 +183,6 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
             learner_submission_data = xblock.get_learner_submission_data()
             data = PageDataSubmissionSerializer(learner_submission_data).data
         assert data == {
-            'hasSubmitted': False,
-            'hasCancelled': False,
-            'hasRecievedGrade': False,
-            'teamInfo': {},
             'response': {
                 'textResponses': ['hello world', 'goodnight moon'],
                 'uploadedFiles': [
@@ -233,10 +225,6 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
             learner_submission_data = xblock.get_learner_submission_data()
             data = PageDataSubmissionSerializer(learner_submission_data).data
         assert data == {
-            'hasSubmitted': True,
-            'hasCancelled': False,
-            'hasRecievedGrade': False,
-            'teamInfo': {},
             'response': {
                 'textResponses': ['hello world', 'goodnight world'],
                 'uploadedFiles': [
@@ -277,19 +265,10 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
             learner_submission_data = xblock.get_learner_submission_data()
             data = PageDataSubmissionSerializer(learner_submission_data).data
         assert data == {
-            'hasSubmitted': False,
-            'hasCancelled': False,
-            'hasRecievedGrade': False,
-            'teamInfo': {
-                'teamName': 'Red Squadron',
-                'teamUsernames': ['Red Leader', 'Red Two', 'Red Five'],
-                'previousTeamName': None,
-                'hasSubmitted': False,
-                'teamUploadedFiles': [],
-            },
             'response': {
                 'textResponses': ['', ''],
-                'uploadedFiles': []
+                'uploadedFiles': [],
+                # 'teamUploadedFiles': []
             },
         }
 
@@ -331,31 +310,6 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
             learner_submission_data = xblock.get_learner_submission_data()
             data = PageDataSubmissionSerializer(learner_submission_data).data
         assert data == {
-            'hasSubmitted': False,
-            'hasCancelled': False,
-            'hasRecievedGrade': False,
-            'teamInfo': {
-                'teamName': 'Red Squadron',
-                'teamUsernames': ['Red Leader', 'Red Two', 'Red Five'],
-                'previousTeamName': None,
-                'hasSubmitted': False,
-                'teamUploadedFiles': [
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/shared1',
-                        'fileName': shared_file_1.name,
-                        'fileDescription': shared_file_1.description,
-                        'fileSize': shared_file_1.size,
-                        'uploadedBy': r1.username,
-                    },
-                    {
-                        'fileUrl': 'www.downloadfiles.xyz/shared2',
-                        'fileName': shared_file_2.name,
-                        'fileDescription': shared_file_2.description,
-                        'fileSize': shared_file_2.size,
-                        'uploadedBy': r2.username,
-                    },
-                ],
-            },
             'response': {
                 'textResponses': ['hello world', 'goodnight moon'],
                 'uploadedFiles': [
@@ -373,7 +327,23 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
                         'fileSize': 3,
                         'fileIndex': 1,
                     },
-                ]
+                ],
+                # 'teamUploadedFiles': [
+                #     {
+                #         'fileUrl': 'www.downloadfiles.xyz/shared1',
+                #         'fileName': shared_file_1.name,
+                #         'fileDescription': shared_file_1.description,
+                #         'fileSize': shared_file_1.size,
+                #         'uploadedBy': r1.username,
+                #     },
+                #     {
+                #         'fileUrl': 'www.downloadfiles.xyz/shared2',
+                #         'fileName': shared_file_2.name,
+                #         'fileDescription': shared_file_2.description,
+                #         'fileSize': shared_file_2.size,
+                #         'uploadedBy': r2.username,
+                #     },
+                # ],
             }
         }
 
@@ -399,15 +369,6 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
             learner_submission_data = xblock.get_learner_submission_data()
             data = PageDataSubmissionSerializer(learner_submission_data).data
         assert data == {
-            'hasSubmitted': True,
-            'hasCancelled': False,
-            'hasRecievedGrade': False,
-            'teamInfo': {
-                'teamName': 'Red Squadron',
-                'teamUsernames': ['Red Leader', 'Red Two', 'Red Five'],
-                'previousTeamName': None,
-                'hasSubmitted': True,
-            },
             'response': {
                 'textResponses': ['This is the answer'],
                 'uploadedFiles': [

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -162,7 +162,8 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
         assert data == {
             'response': {
                 'textResponses': ['', ''],
-                'uploadedFiles': []
+                'uploadedFiles': [],
+                'teamUploadedFiles': [],
             }
         }
 
@@ -177,7 +178,7 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
         student_item = xblock.get_student_item_dict()
         base_key = f'{student_item["student_id"]}/{student_item["course_id"]}/{student_item["item_id"]}'
         with self.mock_get_url({
-            base_key: 'www.downloadfiles.xyz/0',
+            base_key: 'www.example.xyz/0',
             base_key + '/1': 'www.downloadfiles.xyz/1'
         }):
             learner_submission_data = xblock.get_learner_submission_data()
@@ -200,7 +201,8 @@ class GetLearnerSubmissionDataIndividualSubmissionTest(MFEHandlersTestBase):
                         'fileSize': 3,
                         'fileIndex': 1,
                     },
-                ]
+                ],
+                'teamUploadedFiles': [],
             }
         }
 
@@ -268,7 +270,7 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
             'response': {
                 'textResponses': ['', ''],
                 'uploadedFiles': [],
-                # 'teamUploadedFiles': []
+                'teamUploadedFiles': []
             },
         }
 
@@ -328,22 +330,22 @@ class PageDataSubmissionSerializerTest(MFEHandlersTestBase):
                         'fileIndex': 1,
                     },
                 ],
-                # 'teamUploadedFiles': [
-                #     {
-                #         'fileUrl': 'www.downloadfiles.xyz/shared1',
-                #         'fileName': shared_file_1.name,
-                #         'fileDescription': shared_file_1.description,
-                #         'fileSize': shared_file_1.size,
-                #         'uploadedBy': r1.username,
-                #     },
-                #     {
-                #         'fileUrl': 'www.downloadfiles.xyz/shared2',
-                #         'fileName': shared_file_2.name,
-                #         'fileDescription': shared_file_2.description,
-                #         'fileSize': shared_file_2.size,
-                #         'uploadedBy': r2.username,
-                #     },
-                # ],
+                'teamUploadedFiles': [
+                    {
+                        'fileUrl': 'www.downloadfiles.xyz/shared1',
+                        'fileName': shared_file_1.name,
+                        'fileDescription': shared_file_1.description,
+                        'fileSize': shared_file_1.size,
+                        'uploadedBy': r1.username,
+                    },
+                    {
+                        'fileUrl': 'www.downloadfiles.xyz/shared2',
+                        'fileName': shared_file_2.name,
+                        'fileDescription': shared_file_2.description,
+                        'fileSize': shared_file_2.size,
+                        'uploadedBy': r2.username,
+                    },
+                ],
             }
         }
 

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -252,7 +252,16 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
             "activeStepName": "submission",
             "hasReceivedFinalGrade": False,
             "receivedGrades": {},
-            "stepInfo": {"peer": None, "self": None},
+            "stepInfo": {
+                "submission": {
+                    "closed": False,
+                    "closedReason": None,
+                    "hasSubmitted": False,
+                    "hasCancelled": False,
+                },
+                "peer": None,
+                "self": None
+            },
         }
 
         self.assertNestedDictEquals(expected_data, progress_data)
@@ -275,6 +284,12 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
                 "staff": {},
             },
             "stepInfo": {
+                "submission": {
+                    "closed": False,
+                    "closedReason": None,
+                    "hasSubmitted": True,
+                    "hasCancelled": False,
+                },
                 "studentTraining": {
                     "closed": False,
                     "closedReason": None,
@@ -311,6 +326,12 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
                 "staff": {},
             },
             "stepInfo": {
+                "submission": {
+                    "closed": True,
+                    "closedReason": "pastDue",
+                    "hasSubmitted": True,
+                    "hasCancelled": False,
+                },
                 "studentTraining": {
                     "closed": True,
                     "closedReason": "pastDue",
@@ -347,6 +368,12 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
                 "staff": {},
             },
             "stepInfo": {
+                "submission": {
+                    "closed": False,
+                    "closedReason": None,
+                    "hasSubmitted": True,
+                    "hasCancelled": False,
+                },
                 "studentTraining": {
                     "closed": True,
                     "closedReason": "notAvailableYet",
@@ -383,6 +410,12 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
                 "staff": {},
             },
             "stepInfo": {
+                "submission": {
+                    "closed": False,
+                    "closedReason": None,
+                    "hasSubmitted": True,
+                    "hasCancelled": False,
+                },
                 "peer": {
                     "closed": False,
                     "closedReason": None,
@@ -413,6 +446,12 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
                 "staff": {},
             },
             "stepInfo": {
+                "submission": {
+                    "closed": False,
+                    "closedReason": None,
+                    "hasSubmitted": True,
+                    "hasCancelled": False,
+                },
                 "self": {
                     "closed": False,
                     "closedReason": None,
@@ -441,6 +480,12 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
                 "staff": {},
             },
             "stepInfo": {
+                "submission": {
+                    "closed": True,
+                    "closedReason": "pastDue",
+                    "hasSubmitted": True,
+                    "hasCancelled": False,
+                },
                 "peer": None,
                 "self": {
                     "closed": True,
@@ -470,6 +515,12 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
                 "staff": {},
             },
             "stepInfo": {
+                "submission": {
+                    "closed": False,
+                    "closedReason": None,
+                    "hasSubmitted": True,
+                    "hasCancelled": False,
+                },
                 "peer": None,
                 "self": {
                     "closed": True,

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -72,7 +72,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         self.create_test_submission(xblock)
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
+        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
 
         # I get the appropriate response
         expected_response = {
@@ -106,7 +106,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         self.create_test_submission(xblock, student_item=student_item, submission_text=text_responses)
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
+        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
 
         # I get the appropriate response
         expected_response = {
@@ -128,7 +128,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # ... but with no responses to assess
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
+        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
 
         # I get the appropriate response
         expected_response = {}
@@ -145,7 +145,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         self.create_test_submission(xblock)
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
+        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
 
         # Then I get an empty object
         expected_response = {}
@@ -157,7 +157,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         self.create_test_submission(xblock)
 
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
+        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
 
         # Then I get an empty object
         expected_response = {}
@@ -168,7 +168,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # Given I'm on the done step
         self.create_submission_and_assessments(xblock, self.SUBMISSION, [], [], SELF_ASSESSMENT)
         # When I load my response
-        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
+        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
 
         # Then I get an empty object
         expected_response = {}
@@ -193,7 +193,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
 
         # When I try to jump back to that step
         self.context["jump_to_step"] = "peer"
-        response_data = PageDataSerializer(xblock, context=self.context).data["submission"]
+        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
 
         # Then I can continue to receive peer responses to grade
         expected_response = {

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -7,7 +7,6 @@ from json import dumps, loads
 from unittest import TestCase
 from unittest.case import skip
 from unittest.mock import Mock, patch
-from uuid import uuid4
 from openassessment.fileupload.api import TeamFileDescriptor
 from openassessment.xblock.apis.submissions.submissions_actions import create_team_submission
 

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -25,7 +25,7 @@ from openassessment.xblock.ui_mixins.mfe.page_context_serializer import PageData
 
 class TestPageContextSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixin):
     @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.AssessmentResponseSerializer")
-    @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.PageDataSubmissionSerializer")
+    @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.DraftResponseSerializer")
     @scenario("data/basic_scenario.xml", user_id="Alan")
     def test_submission_view(self, xblock, mock_submission_serializer, mock_assessment_serializer):
         # Given we are asking for the submission view
@@ -39,7 +39,7 @@ class TestPageContextSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         mock_assessment_serializer.assert_not_called()
 
     @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.AssessmentResponseSerializer")
-    @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.PageDataSubmissionSerializer")
+    @patch("openassessment.xblock.ui_mixins.mfe.page_context_serializer.SubmissionSerializer")
     @scenario("data/basic_scenario.xml", user_id="Alan")
     def test_assessment_view(self, xblock, mock_submission_serializer, mock_assessment_serializer):
         # Given we are asking for the assessment view

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -84,7 +84,6 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # ... along with these always-none fields assessments
         self.assertIsNone(response_data["hasSubmitted"])
         self.assertIsNone(response_data["hasCancelled"])
-        self.assertIsNone(response_data["hasReceivedGrade"])
         self.assertIsNone(response_data["teamInfo"])
 
     @scenario("data/peer_only_scenario.xml", user_id="Alan")
@@ -119,7 +118,6 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # ... along with these always-none fields assessments
         self.assertIsNone(response_data["hasSubmitted"])
         self.assertIsNone(response_data["hasCancelled"])
-        self.assertIsNone(response_data["hasReceivedGrade"])
         self.assertIsNone(response_data["teamInfo"])
 
     @scenario("data/peer_only_scenario.xml", user_id="Alan")
@@ -139,7 +137,6 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # ... along with these always-none fields assessments
         self.assertIsNone(response_data["hasSubmitted"])
         self.assertIsNone(response_data["hasCancelled"])
-        self.assertIsNone(response_data["hasReceivedGrade"])
         self.assertIsNone(response_data["teamInfo"])
 
     @scenario("data/staff_grade_scenario.xml", user_id="Alan")

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -20,7 +20,11 @@ from openassessment.xblock.test.base import (
     scenario,
 )
 from openassessment.xblock.test.test_submission import setup_mock_team
-from openassessment.xblock.ui_mixins.mfe.page_context_serializer import PageDataSerializer, ProgressSerializer, TeamInfoSerializer
+from openassessment.xblock.ui_mixins.mfe.page_context_serializer import (
+    PageDataSerializer,
+    ProgressSerializer,
+    TeamInfoSerializer,
+)
 
 
 class TestPageContextSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixin):
@@ -232,6 +236,7 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         # this context when the step name is valid.
         with self.assertRaises(Exception):
             _ = PageDataSerializer(xblock, context=self.context).data
+
 
 class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
     # Show full dict diffs
@@ -587,6 +592,7 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         }
 
         self.assertNestedDictEquals(expected_data, progress_data)
+
 
 class TestTeamInfoSerializer(TestCase):
     def test_serialize(self):

--- a/openassessment/xblock/ui_mixins/mfe/test_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_serializers.py
@@ -306,8 +306,8 @@ class TestPeerSettingsSerializer(XBlockHandlerTestCase):
         ]
 
         # Then I get the right dates
-        self.assertEqual(peer_config["startTime"], expected_start)
-        self.assertEqual(peer_config["endTime"], expected_due)
+        self.assertEqual(peer_config["startDatetime"], expected_start)
+        self.assertEqual(peer_config["endDatetime"], expected_due)
 
     @scenario("data/peer_assessment_flex_grading_scenario.xml")
     def test_flex_grading(self, xblock):

--- a/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
@@ -4,9 +4,8 @@ import ddt
 
 from openassessment.fileupload.api import FileDescriptor, TeamFileDescriptor
 from openassessment.xblock.ui_mixins.mfe.submission_serializers import (
-    InProgressResponseSerializer,
-    SubmissionSerializer,
-    PageDataSubmissionSerializer
+    DraftResponseSerializer,
+    SubmissionSerializer
 )
 from openassessment.data import OraSubmissionAnswer, SubmissionFileUpload
 
@@ -40,8 +39,22 @@ class TestSubmissionSerializer(TestCase):
         mock_uploaded_files = [
             _mock_uploaded_file(file_id) for file_id in [1, 22]
         ]
-        mock_submission_answer = MockOraSubmissionAnswer(mock_text_responses, mock_uploaded_files)
-        assert SubmissionSerializer(mock_submission_answer).data == {
+        data = {
+            'workflow': {
+                'has_submitted': True,
+                'has_cancelled': False,
+                'has_received_grade': True,
+            },
+            'team_info': {
+                'team_name': 'Team1',
+                'team_usernames': ['Bob', 'Alice'],
+                'previous_team_name': None,
+                'has_submitted': True,
+            },
+            'response': MockOraSubmissionAnswer(mock_text_responses, mock_uploaded_files),
+            'file_data': []
+        }
+        assert SubmissionSerializer(data).data == {
             'textResponses': mock_text_responses,
             'uploadedFiles': [
                 {
@@ -58,18 +71,35 @@ class TestSubmissionSerializer(TestCase):
                     'fileSize': 22,
                     'fileIndex': 1
                 }
-            ]
+            ],
+            "teamUploadedFiles": None
         }
 
     def test_empty(self):
-        mock_submission_answer = MockOraSubmissionAnswer([], [])
-        assert SubmissionSerializer(mock_submission_answer).data == {
+        data = {
+            'workflow': {
+                'has_submitted': True,
+                'has_cancelled': False,
+                'has_received_grade': True,
+            },
+            'team_info': {
+                'team_name': 'Team1',
+                'team_usernames': ['Bob', 'Alice'],
+                'previous_team_name': None,
+                'has_submitted': True,
+            },
+            'response': MockOraSubmissionAnswer([], []),
+            'file_data': []
+        }
+        assert SubmissionSerializer(data).data == {
             'textResponses': [],
-            'uploadedFiles': []
+            'uploadedFiles': [],
+            'teamUploadedFiles': None
         }
 
 
-class TestInProgressResponseSerializer(TestCase):
+class TestDraftResponseSerializer(TestCase):
+
     def test_serializer(self):
         data = {
             'response': {
@@ -91,7 +121,7 @@ class TestInProgressResponseSerializer(TestCase):
                 FileDescriptor('www.mysite.com/files/22', 'desc-22', 'name-22', 22, True)._asdict(),
             ]
         }
-        assert InProgressResponseSerializer(data).data == {
+        assert DraftResponseSerializer(data).data == {
             'textResponses': [
                 'Response to prompt 1',
                 'Response to prompt 2'
@@ -111,7 +141,8 @@ class TestInProgressResponseSerializer(TestCase):
                     'fileSize': 22,
                     'fileIndex': 1
                 }
-            ]
+            ],
+            'teamUploadedFiles': None,
         }
 
     def test_empty(self):
@@ -132,15 +163,19 @@ class TestInProgressResponseSerializer(TestCase):
             },
             'file_data': []
         }
-        assert InProgressResponseSerializer(data).data == {
+        assert DraftResponseSerializer(data).data == {
             'textResponses': ['', ''],
             'uploadedFiles': [],
+            'teamUploadedFiles': None,
         }
 
 
 
 @ddt.ddt
-class TestPageDataSubmissionSerializer(TestCase):
+class TestPageDataResponseSerializer(TestCase):
+
+    # Show full dictionary diffs
+    maxDiff = None
 
     def test_integration_not_submitted(self):
         data = {
@@ -178,45 +213,43 @@ class TestPageDataSubmissionSerializer(TestCase):
                 FileDescriptor('www.mysite.com/files/22', 'desc-22', 'name-22', 22, True)._asdict(),
             ]
         }
-        assert PageDataSubmissionSerializer(data).data == {
-            'response': {
-                'textResponses': [
-                    'Response to prompt 1',
-                    'Response to prompt 2'
-                ],
-                'uploadedFiles': [
-                    {
-                        'fileUrl': 'www.mysite.com/files/1',
-                        'fileDescription': 'desc-1',
-                        'fileName': 'name-1',
-                        'fileSize': 1,
-                        'fileIndex': 0
-                    },
-                    {
-                        'fileUrl': 'www.mysite.com/files/22',
-                        'fileDescription': 'desc-22',
-                        'fileName': 'name-22',
-                        'fileSize': 22,
-                        'fileIndex': 1
-                    }
-                ],
-                'teamUploadedFiles': [
-                    {
-                        'fileUrl': 'www.mysite.com/files/123',
-                        'fileDescription': 'desc-123',
-                        'fileName': 'name-123',
-                        'fileSize': 123,
-                        'uploadedBy': 'Bob'
-                    },
-                    {
-                        'fileUrl': 'www.mysite.com/files/5555',
-                        'fileDescription': 'desc-5555',
-                        'fileName': 'name-5555',
-                        'fileSize': 5555,
-                        'uploadedBy': 'Billy'
-                    }
-                ]
-            }
+        assert DraftResponseSerializer(data).data == {
+            'textResponses': [
+                'Response to prompt 1',
+                'Response to prompt 2'
+            ],
+            'uploadedFiles': [
+                {
+                    'fileUrl': 'www.mysite.com/files/1',
+                    'fileDescription': 'desc-1',
+                    'fileName': 'name-1',
+                    'fileSize': 1,
+                    'fileIndex': 0
+                },
+                {
+                    'fileUrl': 'www.mysite.com/files/22',
+                    'fileDescription': 'desc-22',
+                    'fileName': 'name-22',
+                    'fileSize': 22,
+                    'fileIndex': 1
+                }
+            ],
+            'teamUploadedFiles': [
+                {
+                    'fileUrl': 'www.mysite.com/files/123',
+                    'fileDescription': 'desc-123',
+                    'fileName': 'name-123',
+                    'fileSize': 123,
+                    'uploadedBy': 'Bob'
+                },
+                {
+                    'fileUrl': 'www.mysite.com/files/5555',
+                    'fileDescription': 'desc-5555',
+                    'fileName': 'name-5555',
+                    'fileSize': 5555,
+                    'uploadedBy': 'Billy'
+                }
+            ]
         }
 
     def test_integration_submitted(self):
@@ -246,41 +279,40 @@ class TestPageDataSubmissionSerializer(TestCase):
             ),
             'file_data': []
         }
-        assert PageDataSubmissionSerializer(data).data == {
-            'response': {
-                'textResponses': [
-                    'Response to prompt 1',
-                    'Response to prompt 2'
-                ],
-                'uploadedFiles': [
-                    {
-                        'fileUrl': 'www.mysite.com/files/1',
-                        'fileDescription': 'desc-1',
-                        'fileName': 'name-1',
-                        'fileSize': 1,
-                        'fileIndex': 0
-                    },
-                    {
-                        'fileUrl': 'www.mysite.com/files/22',
-                        'fileDescription': 'desc-22',
-                        'fileName': 'name-22',
-                        'fileSize': 22,
-                        'fileIndex': 1
-                    },
-                    {
-                        'fileUrl': 'www.mysite.com/files/123',
-                        'fileDescription': 'desc-123',
-                        'fileName': 'name-123',
-                        'fileSize': 123,
-                        'fileIndex': 2
-                    },
-                    {
-                        'fileUrl': 'www.mysite.com/files/5555',
-                        'fileDescription': 'desc-5555',
-                        'fileName': 'name-5555',
-                        'fileSize': 5555,
-                        'fileIndex': 3
-                    }
-                ]
-            }
+        assert SubmissionSerializer(data).data == {
+            'textResponses': [
+                'Response to prompt 1',
+                'Response to prompt 2'
+            ],
+            'uploadedFiles': [
+                {
+                    'fileUrl': 'www.mysite.com/files/1',
+                    'fileDescription': 'desc-1',
+                    'fileName': 'name-1',
+                    'fileSize': 1,
+                    'fileIndex': 0
+                },
+                {
+                    'fileUrl': 'www.mysite.com/files/22',
+                    'fileDescription': 'desc-22',
+                    'fileName': 'name-22',
+                    'fileSize': 22,
+                    'fileIndex': 1
+                },
+                {
+                    'fileUrl': 'www.mysite.com/files/123',
+                    'fileDescription': 'desc-123',
+                    'fileName': 'name-123',
+                    'fileSize': 123,
+                    'fileIndex': 2
+                },
+                {
+                    'fileUrl': 'www.mysite.com/files/5555',
+                    'fileDescription': 'desc-5555',
+                    'fileName': 'name-5555',
+                    'fileSize': 5555,
+                    'fileIndex': 3
+                }
+            ],
+            "teamUploadedFiles": None,
         }

--- a/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
@@ -237,8 +237,6 @@ class TestPageDataSubmissionSerializer(TestCase):
             ]
         }
         assert PageDataSubmissionSerializer(data).data == {
-            'hasSubmitted': False,
-            'hasCancelled': False,
             'teamInfo': {
                 'teamName': 'Team1',
                 'teamUsernames': ['Bob', 'Alice'],
@@ -290,6 +288,7 @@ class TestPageDataSubmissionSerializer(TestCase):
             'workflow': {
                 'has_submitted': True,
                 'has_cancelled': False,
+                'has_recieved_grade': True,
             },
             'team_info': {
                 'team_name': 'Team1',
@@ -312,8 +311,6 @@ class TestPageDataSubmissionSerializer(TestCase):
             'file_data': []
         }
         assert PageDataSubmissionSerializer(data).data == {
-            'hasSubmitted': True,
-            'hasCancelled': False,
             'teamInfo': {
                 'teamName': 'Team1',
                 'teamUsernames': ['Bob', 'Alice'],

--- a/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
@@ -147,7 +147,7 @@ class TestPageDataSubmissionSerializer(TestCase):
             'workflow': {
                 'has_submitted': False,
                 'has_cancelled': False,
-                'has_recieved_grade': False,
+                'has_received_grade': False,
             },
             'team_info': {
                 'team_name': 'Team1',
@@ -224,7 +224,7 @@ class TestPageDataSubmissionSerializer(TestCase):
             'workflow': {
                 'has_submitted': True,
                 'has_cancelled': False,
-                'has_recieved_grade': True,
+                'has_received_grade': True,
             },
             'team_info': {
                 'team_name': 'Team1',

--- a/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
@@ -170,7 +170,6 @@ class TestDraftResponseSerializer(TestCase):
         }
 
 
-
 @ddt.ddt
 class TestPageDataResponseSerializer(TestCase):
 

--- a/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
@@ -199,22 +199,22 @@ class TestPageDataSubmissionSerializer(TestCase):
                         'fileSize': 22,
                         'fileIndex': 1
                     }
-                    # 'teamUploadedFiles': [
-                    #     {
-                    #         'fileUrl': 'www.mysite.com/files/123',
-                    #         'fileDescription': 'desc-123',
-                    #         'fileName': 'name-123',
-                    #         'fileSize': 123,
-                    #         'uploadedBy': 'Bob'
-                    #     },
-                    #     {
-                    #         'fileUrl': 'www.mysite.com/files/5555',
-                    #         'fileDescription': 'desc-5555',
-                    #         'fileName': 'name-5555',
-                    #         'fileSize': 5555,
-                    #         'uploadedBy': 'Billy'
-                    #     }
-                    # ]
+                ],
+                'teamUploadedFiles': [
+                    {
+                        'fileUrl': 'www.mysite.com/files/123',
+                        'fileDescription': 'desc-123',
+                        'fileName': 'name-123',
+                        'fileSize': 123,
+                        'uploadedBy': 'Bob'
+                    },
+                    {
+                        'fileUrl': 'www.mysite.com/files/5555',
+                        'fileDescription': 'desc-5555',
+                        'fileName': 'name-5555',
+                        'fileSize': 5555,
+                        'uploadedBy': 'Billy'
+                    }
                 ]
             }
         }

--- a/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
@@ -6,7 +6,6 @@ from openassessment.fileupload.api import FileDescriptor, TeamFileDescriptor
 from openassessment.xblock.ui_mixins.mfe.submission_serializers import (
     InProgressResponseSerializer,
     SubmissionSerializer,
-    TeamInfoSerializer,
     PageDataSubmissionSerializer
 )
 from openassessment.data import OraSubmissionAnswer, SubmissionFileUpload
@@ -139,63 +138,6 @@ class TestInProgressResponseSerializer(TestCase):
         }
 
 
-class TestTeamInfoSerializer(TestCase):
-    def test_serialize(self):
-        team_info = {
-            'team_name': 'Team1',
-            'team_usernames': ['Bob', 'Alice'],
-            'previous_team_name': 'Team4',
-            'has_submitted': True,
-            'team_uploaded_files': [
-                TeamFileDescriptor('www.mysite.com/files/123', 'desc-123', 'name-123', 123, 'Chrissy')._asdict(),
-                TeamFileDescriptor('www.mysite.com/files/5555', 'desc-5555', 'name-5555', 5555, 'Billy')._asdict(),
-            ]
-        }
-        assert TeamInfoSerializer(team_info).data == {
-            'teamName': 'Team1',
-            'teamUsernames': ['Bob', 'Alice'],
-            'previousTeamName': 'Team4',
-            'hasSubmitted': True,
-            'teamUploadedFiles': [
-                {
-                    'fileUrl': 'www.mysite.com/files/123',
-                    'fileDescription': 'desc-123',
-                    'fileName': 'name-123',
-                    'fileSize': 123,
-                    'uploadedBy': 'Chrissy'
-                },
-                {
-                    'fileUrl': 'www.mysite.com/files/5555',
-                    'fileDescription': 'desc-5555',
-                    'fileName': 'name-5555',
-                    'fileSize': 5555,
-                    'uploadedBy': 'Billy'
-                }
-            ]
-        }
-
-    def test_no_team(self):
-        team_info = {
-            'team_uploaded_files': []
-        }
-        assert not TeamInfoSerializer(team_info).data
-
-    def test_no_files(self):
-        team_info = {
-            'team_name': 'Team1',
-            'team_usernames': ['Bob', 'Alice'],
-            'previous_team_name': None,
-            'has_submitted': False,
-            'team_uploaded_files': []
-        }
-        assert TeamInfoSerializer(team_info).data == {
-            'teamName': 'Team1',
-            'teamUsernames': ['Bob', 'Alice'],
-            'previousTeamName': None,
-            'hasSubmitted': False,
-            'teamUploadedFiles': [],
-        }
-
 
 @ddt.ddt
 class TestPageDataSubmissionSerializer(TestCase):
@@ -237,28 +179,6 @@ class TestPageDataSubmissionSerializer(TestCase):
             ]
         }
         assert PageDataSubmissionSerializer(data).data == {
-            'teamInfo': {
-                'teamName': 'Team1',
-                'teamUsernames': ['Bob', 'Alice'],
-                'previousTeamName': None,
-                'hasSubmitted': False,
-                'teamUploadedFiles': [
-                    {
-                        'fileUrl': 'www.mysite.com/files/123',
-                        'fileDescription': 'desc-123',
-                        'fileName': 'name-123',
-                        'fileSize': 123,
-                        'uploadedBy': 'Bob'
-                    },
-                    {
-                        'fileUrl': 'www.mysite.com/files/5555',
-                        'fileDescription': 'desc-5555',
-                        'fileName': 'name-5555',
-                        'fileSize': 5555,
-                        'uploadedBy': 'Billy'
-                    }
-                ]
-            },
             'response': {
                 'textResponses': [
                     'Response to prompt 1',
@@ -279,6 +199,22 @@ class TestPageDataSubmissionSerializer(TestCase):
                         'fileSize': 22,
                         'fileIndex': 1
                     }
+                    # 'teamUploadedFiles': [
+                    #     {
+                    #         'fileUrl': 'www.mysite.com/files/123',
+                    #         'fileDescription': 'desc-123',
+                    #         'fileName': 'name-123',
+                    #         'fileSize': 123,
+                    #         'uploadedBy': 'Bob'
+                    #     },
+                    #     {
+                    #         'fileUrl': 'www.mysite.com/files/5555',
+                    #         'fileDescription': 'desc-5555',
+                    #         'fileName': 'name-5555',
+                    #         'fileSize': 5555,
+                    #         'uploadedBy': 'Billy'
+                    #     }
+                    # ]
                 ]
             }
         }
@@ -311,12 +247,6 @@ class TestPageDataSubmissionSerializer(TestCase):
             'file_data': []
         }
         assert PageDataSubmissionSerializer(data).data == {
-            'teamInfo': {
-                'teamName': 'Team1',
-                'teamUsernames': ['Bob', 'Alice'],
-                'previousTeamName': None,
-                'hasSubmitted': True,
-            },
             'response': {
                 'textResponses': [
                     'Response to prompt 1',

--- a/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_submission_serializers.py
@@ -239,7 +239,6 @@ class TestPageDataSubmissionSerializer(TestCase):
         assert PageDataSubmissionSerializer(data).data == {
             'hasSubmitted': False,
             'hasCancelled': False,
-            'hasRecievedGrade': False,
             'teamInfo': {
                 'teamName': 'Team1',
                 'teamUsernames': ['Bob', 'Alice'],
@@ -291,7 +290,6 @@ class TestPageDataSubmissionSerializer(TestCase):
             'workflow': {
                 'has_submitted': True,
                 'has_cancelled': False,
-                'has_recieved_grade': True,
             },
             'team_info': {
                 'team_name': 'Team1',
@@ -316,7 +314,6 @@ class TestPageDataSubmissionSerializer(TestCase):
         assert PageDataSubmissionSerializer(data).data == {
             'hasSubmitted': True,
             'hasCancelled': False,
-            'hasRecievedGrade': True,
             'teamInfo': {
                 'teamName': 'Team1',
                 'teamUsernames': ['Bob', 'Alice'],


### PR DESCRIPTION
**TL;DR -** A bunch of things needed to change on the contract, see details below.

JIRA:  [AU-1481](https://2u-internal.atlassian.net/browse/AU-1481)

**What changed?**

- Remove `rubric` from `progress`. (3e3c045595c5f46e36539e8b69e08c02873384c8)
- Remove `hasReceivedGrade` from `submission`. (e7f0c35540f1e6a9abfd8731f54bb5064379d3b0)
- Move `submission` status from `submission` into `stepInfo`. (32b0f141870d5e64f91deefdd2ca59e85b324fab)
    - Add `isClosed` and `closedReason` to `submission`.
- Rename `submission` to `response` (063d2a8f7c19d9cccbce8839c17d43061ce1d3bb)
- Combine `get_learner_block_submission`/`assessments_data` into single `get_learner_data` call (4723d8ef3af32157666b11f4c7f8c3aa15ad39d5)
- Move `teamInfo` from `response` info`stepInfo`. (b8f2896133eae7d0dcf23f9a1e212bce9c72153b)
- Move team file uploads to `response`. (47847abbaef049194afa8591ecf7624bc79acae4)
- Move `response` up a level (d517e538e227c842cc109b312ef8859db9d63ea6)
- Update all `startTime` / `endTime` to `startDatetime` and `endDatetime`. (f84ac3129035598b0457ff1a3951e7a01bd6c9c9)
- Other various cleanups & refactors.
    - Always show peer and submission step info once we've reached those steps.


**Testing Instructions**

- Unit tests
- Use Postman or other API tool to exercise `{{protocol}}://{{lms_url}}/courses/{{course_id}}/xblock/{{block_id}}/handler/get_learner_data/{{jump_step}}`

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
