### PR TITLE
test: fix failing tests by mocking xmodule runtime

### DIFF
--- a/openassessment/xblock/test/base.py
+++ b/openassessment/xblock/test/base.py
@@ -310,6 +310,30 @@ class XBlockHandlerTestCaseMixin:
         with open(os.path.join(base_dir, path)) as file_handle:
             return file_handle.read()
 
+    @staticmethod
+    def _create_mock_runtime(
+            item_id,
+            is_staff,
+            is_admin,
+            anonymous_user_id,
+            user_is_beta=False,
+    ):
+        """
+        Internal helper to define a mock runtime.
+        """
+        mock_runtime = mock.Mock(
+            course_id='test_course',
+            item_id=item_id,
+            anonymous_student_id=anonymous_user_id,
+            user_is_staff=is_staff,
+            user_is_admin=is_admin,
+            user_is_beta=user_is_beta,
+            service=lambda self, service: mock.Mock(
+                get_anonymous_student_id=lambda user_id, course_id: anonymous_user_id
+            )
+        )
+        return mock_runtime
+
 
 class XBlockHandlerTestCase(XBlockHandlerTestCaseMixin, CacheResetTest):
     """

--- a/openassessment/xblock/test/test_leaderboard.py
+++ b/openassessment/xblock/test/test_leaderboard.py
@@ -27,6 +27,10 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
     @scenario('data/basic_scenario.xml')
     def test_no_leaderboard(self, xblock):
         xblock.mfe_views_enabled = False
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
+
         # Since there's no leaderboard set in the problem XML,
         # it should not be visible
         self._assert_leaderboard_visible(xblock, False)
@@ -34,6 +38,9 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
     @scenario('data/leaderboard_unavailable.xml')
     def test_unavailable(self, xblock):
         xblock.mfe_views_enabled = False
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         # Start date is in the future for this scenario
         self._assert_path_and_context(
             xblock,
@@ -44,6 +51,9 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
 
     @scenario('data/leaderboard_show.xml')
     def test_show_no_submissions(self, xblock):
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         xblock.mfe_views_enabled = False
         # No submissions created yet, so the leaderboard shouldn't display any scores
         self._assert_scores(xblock, [])
@@ -52,6 +62,10 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
     @scenario('data/leaderboard_show.xml')
     def test_show_submissions(self, xblock):
         xblock.mfe_views_enabled = False
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
+
         # Create some submissions (but fewer than the max that can be shown)
         self._create_submissions_and_scores(xblock, [
             (prepare_submission_for_serialization(('test answer 1 part 1', 'test answer 1 part 2')), 1),
@@ -98,6 +112,9 @@ class TestLeaderboardRender(XBlockHandlerTransactionTestCase):
     @scenario('data/leaderboard_show.xml')
     def test_show_submissions_that_have_greater_than_0_score(self, xblock):
         xblock.mfe_views_enabled = False
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         # Create some submissions (but fewer than the max that can be shown)
         self._create_submissions_and_scores(xblock, [
             (prepare_submission_for_serialization(('test answer 0 part 1', 'test answer 0 part 2')), 0),

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -79,6 +79,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         Open Assessment XBlock. We don't want to match too heavily against the
         contents.
         """
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         xblock.mfe_views_enabled = True
         xblock_fragment = self.runtime.render(xblock, "student_view")
         self.assertIn("OpenAssessmentBlock", xblock_fragment.body_html())
@@ -284,6 +287,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
     @scenario('data/empty_prompt.xml')
     def test_prompt_intentionally_empty(self, xblock):
         xblock.mfe_views_enabled = True
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         # Verify that prompts intentionally left empty don't create DOM elements
         xblock_fragment = self.runtime.render(xblock, "student_view")
         body_html = xblock_fragment.body_html()
@@ -294,6 +300,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
 
     @scenario('data/basic_scenario.xml')
     def test_page_load_updates_workflow(self, xblock):
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         xblock.mfe_views_enabled = True
 
         # No submission made, so don't update the workflow
@@ -315,6 +324,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
     @scenario('data/basic_scenario.xml')
     def test_student_view_workflow_error(self, xblock):
         xblock.mfe_views_enabled = True
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
 
         # Simulate an error from updating the workflow
         xblock.submission_uuid = 'test_submission'
@@ -339,6 +351,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
             time_zone_fn.return_value['user_timezone'] = pytz.timezone(time_zone)
 
             xblock = self.load_scenario('data/dates_scenario.xml')
+            xblock.xmodule_runtime = self._create_mock_runtime(
+                xblock.scope_ids.usage_id, False, False, "Bob"
+            )
             xblock.mfe_views_enabled = True
             xblock_fragment = self.runtime.render(xblock, "student_view")
             self.assertIn("OpenAssessmentBlock", xblock_fragment.body_html())
@@ -520,7 +535,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
 
     @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_default_fields(self, xblock):
-
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         # Reset all fields in the XBlock to their default values
         for field_name, field in xblock.fields.items():
             setattr(xblock, field_name, field.default)
@@ -552,6 +569,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
     @scenario('data/basic_scenario.xml', user_id='Bob')
     def test_ignore_unknown_assessment_types(self, xblock):
         xblock.mfe_views_enabled = True
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         # If the XBlock contains an unknown assessment type
         # (perhaps after a roll-back), it should ignore it.
         xblock.rubric_assessments.append({'name': 'unknown'})
@@ -565,6 +585,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
 
     @scenario('data/grade_scenario_self_staff.xml', user_id='Bob')
     def test_assessment_type_with_staff(self, xblock):
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         xblock.mfe_views_enabled = True
         # Check that staff-assessment is in assessment_steps
         self.assertIn('staff-assessment', xblock.assessment_steps)
@@ -574,6 +597,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
 
     @scenario('data/grade_scenario_self_only.xml', user_id='Bob')
     def test_assessment_type_without_staff(self, xblock):
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         xblock.mfe_views_enabled = True
         # Check that staff-assessment is not in assessment_steps
         self.assertNotIn('staff-assessment', xblock.assessment_steps)
@@ -584,6 +610,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
     @scenario('data/grade_scenario_self_staff_not_required.xml', user_id='Bob')
     def test_assessment_type_with_staff_not_required(self, xblock):
         xblock.mfe_views_enabled = True
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         StaffAssessmentAPI.staff_assessment_exists = lambda submission_uuid: False
         # Check that staff-assessment is not in assessment_steps
         self.assertNotIn('staff-assessment', xblock.assessment_steps)
@@ -594,6 +623,9 @@ class TestOpenAssessment(XBlockHandlerTestCase):
     @scenario('data/grade_scenario_self_staff_not_required.xml', user_id='Bob')
     def test_assessment_type_with_staff_override(self, xblock):
         xblock.mfe_views_enabled = True
+        xblock.xmodule_runtime = self._create_mock_runtime(
+            xblock.scope_ids.usage_id, False, False, "Bob"
+        )
         # Override the staff_assessment_exists function to always return True
         StaffAssessmentAPI.staff_assessment_exists = lambda submission_uuid: True
 

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -1437,30 +1437,6 @@ class TestCourseStaff(XBlockHandlerTestCase):
             self.assertEqual(in_progress, context['staff_assessment_in_progress'])
 
     @staticmethod
-    def _create_mock_runtime(
-            item_id,
-            is_staff,
-            is_admin,
-            anonymous_user_id,
-            user_is_beta=False,
-    ):
-        """
-        Internal helper to define a mock runtime.
-        """
-        mock_runtime = Mock(
-            course_id='test_course',
-            item_id=item_id,
-            anonymous_student_id=anonymous_user_id,
-            user_is_staff=is_staff,
-            user_is_admin=is_admin,
-            user_is_beta=user_is_beta,
-            service=lambda self, service: Mock(
-                get_anonymous_student_id=lambda user_id, course_id: anonymous_user_id
-            )
-        )
-        return mock_runtime
-
-    @staticmethod
     def _create_submission(item, values, types):
         """ Create a submission and corresponding workflow. """
         submission = sub_api.create_submission(item, values)

--- a/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/submission_serializers.py
@@ -2,6 +2,7 @@
 # pylint: disable=abstract-method
 
 from rest_framework.serializers import (
+    BooleanField,
     IntegerField,
     Serializer,
     CharField,


### PR DESCRIPTION
Some test failures were merged into the feature branch. This PR is a quick fix. More work should be done in the future to remove all references to the xmodule runtime