### PR TITLE
feat: ORA staff grader mfe endpoints upgraded

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -95,6 +95,48 @@ def map_anonymized_ids_to_usernames(anonymized_ids):
 
     return anonymous_id_to_username_mapping
 
+def map_anonymized_ids_to_emails(anonymized_ids):
+    """
+    Args:
+        anonymized_ids - list of anonymized user ids.
+    Returns:
+        dictionary, that contains mapping between anonymized user ids and
+        actual user emails.
+    """
+    User = get_user_model()
+
+    users = _use_read_replica(
+        User.objects.filter(anonymoususerid__anonymous_user_id__in=anonymized_ids)
+        .annotate(anonymous_id=F("anonymoususerid__anonymous_user_id"))
+        .values("email", "anonymous_id")
+    )
+    anonymous_id_to_email_mapping = {
+        user["anonymous_id"]: user["email"] for user in users
+    }
+    return anonymous_id_to_email_mapping
+
+
+def map_anonymized_ids_to_fullname(anonymized_ids):
+    """
+    Args:
+        anonymized_ids - list of anonymized user ids.
+    Returns:
+        dictionary, that contains mapping between anonymized user ids and
+        actual user fullname.
+    """
+    User = get_user_model()
+
+    users = _use_read_replica(
+        User.objects.filter(anonymoususerid__anonymous_user_id__in=anonymized_ids)
+        .select_related("profile")
+        .annotate(anonymous_id=F("anonymoususerid__anonymous_user_id"))
+        .values("profile__name", "anonymous_id")
+    )
+
+    anonymous_id_to_fullname_mapping = {
+        user["anonymous_id"]: user["profile__name"] for user in users
+    }
+    return anonymous_id_to_fullname_mapping
 
 class CsvWriter:
     """

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -211,25 +211,28 @@ class StaffGraderMixin:
             data (dict): Contains the necessary information to fetch the assessments.
                         - 'item_id': The ID of the xblock/item.
                         - 'submission_uuid': The UUID of the submission.
-                        - 'assessment_type': A string, either "received" or any other value 
+                        - 'assessment_filter': A string, either "received" or any other value
                                             to determine the type of assessments to retrieve.
 
         Returns:
             list[dict]: A list of dictionaries, each representing an assessment's data.
 
         Note:
-            - If 'assessment_type' is "received", the function fetches assessments received 
+            - If 'assessment_filter' is "received", the function fetches assessments received
             for the given 'submission_uuid'.
-            - For any other value of 'assessment_type', the function fetches assessments 
+            - For any other value of 'assessment_filter', the function fetches assessments
             given by the owner of the 'submission_uuid' for other submissions in the same item.
         """
         item_id = data['item_id']
         subission_uuid = data['submission_uuid']
+        filter_value = data['assessment_filter']
 
-        if data['assessment_type'] == "received":
+        if filter_value == "received":
             return generate_received_assessment_data(subission_uuid)
-        else:
+        elif filter_value == "given":
             return generate_given_assessment_data(item_id, subission_uuid)
+        else:
+            raise ValueError("Invalid assessment_filter value")
 
 
     def _get_list_workflows_serializer_context(self, staff_workflows, is_team_assignment=False):

--- a/openassessment/staffgrader/tests/test_list_staff_workflows.py
+++ b/openassessment/staffgrader/tests/test_list_staff_workflows.py
@@ -160,12 +160,11 @@ class TestStaffWorkflowListViewBase(XBlockHandlerTestCase):
         Context manager that patches map_anonymized_ids_to_user_data and returns a mapping from student IDs to a dictionary
         containing username, email, and fullname.
         """
-        # Creamos un diccionario simulado que represente lo que la función real devuelve
         mock_data = {
             student_id: {
                 "username": self.student_id_to_username_map.get(student_id, ""),
-                "email": "mocked_email@example.com",  # O quizás puedes usar un mapa similar para emails si es necesario
-                "fullname": "Mocked Full Name"  # O quizás puedes usar un mapa similar para nombres completos si es necesario
+                "email": "mocked_email@example.com",
+                "fullname": "Mocked Full Name"
             }
             for student_id in self.student_id_to_username_map
         }
@@ -632,7 +631,7 @@ class StaffWorkflowListViewUnitTests(TestStaffWorkflowListViewBase):
         ]
 
         with self._mock_get_student_ids_by_submission_uuid() as mock_get_student_ids:
-            with self._mock_map_anonymized_ids_to_user_data() as mock_map_data:  # Cambio importante aquí
+            with self._mock_map_anonymized_ids_to_user_data() as mock_map_data:
                 with patch.object(xblock, 'bulk_deep_fetch_assessments') as mock_bulk_fetch_assessments:
                     context = xblock._get_list_workflows_serializer_context(mock_staff_workflows)  # pylint: disable=protected-access
 
@@ -647,7 +646,7 @@ class StaffWorkflowListViewUnitTests(TestStaffWorkflowListViewBase):
         expected_anonymous_id_lookups.update(
             {self.course_staff[1].student_id, self.course_staff[2].student_id}
         )
-        mock_map_data.assert_called_once_with(expected_anonymous_id_lookups)  # Cambio importante aquí
+        mock_map_data.assert_called_once_with(expected_anonymous_id_lookups)
         mock_bulk_fetch_assessments.assert_called_once_with(mock_staff_workflows)
 
         expected_context = {


### PR DESCRIPTION
# ORA staff grader endpoints upgrade

For this PR we have the following goals:

-  Create the `/api/ora_staff_grader/assessments/feedback` endpoint in order to list the assessments grades based on the type (received or given) for a specific submission.
- Update the `/api/ora_staff_grader/initialize` endpoint in order to add the `fullname` and `email` fields.

# Descriptions

## /api/ora_staff_grader/assessments/feedback
This endpoint fetches assessment details for a given submission UUID, assessment_fillter [`given`, `received`] and ORA_location, including scorer information and scoring details in order to fill the following Staff Grade MFE table:
<p align="center">
  <img src="https://github.com/eduNEXT/edx-ora2/assets/12719909/0b5f7d33-e3d3-4816-b986-f52f169b356e" width="600" alt="Descripción alternativa 1">
</p>

Modifications were made in the following directories:

> #### edx-ora2
> - openassessment/staffgrader/staff_grader_mixin.py
> - openassessment/data.py
> #### edx-platform
> - lms/djangoapps/ora_staff_grader/constants.py
> - lms/djangoapps/ora_staff_grader/ora_api.py
> - lms/djangoapps/ora_staff_grader/serializers.py
> - lms/djangoapps/ora_staff_grader/urls.py
> - lms/djangoapps/ora_staff_grader/views.py


<details>
  <summary>Click here! to see `/api/ora_staff_grader/assessments/feedback` output</summary>

```json
  {
      "assessments": [
          {
              "id_assessment": "17",
              "scorer_name": "Fernando Gonzalez",
              "scorer_username": "admin",
              "scorer_email": "admin@admin.com",
              "assesment_date": "17-10-2023",
              "assesment_scores": [
                  {
                      "criterion_name": "Ideas",
                      "score_earned": 5,
                      "score_type": "Good"
                  },
                  {
                      "criterion_name": "Content",
                      "score_earned": 5,
                      "score_type": "Excellent"
                  }
              ],
              "problem_step": "Staff",
              "feedback": "OVERALL WENO"
          },
      ]
  }
```
</details>

&nbsp;

&nbsp;
## /api/ora_staff_grader/initialize
This is a pre-existing endpoint to which two extra fields are added [`fullname`, `email`].

<p align="center">
  <img src="https://github.com/eduNEXT/edx-ora2/assets/12719909/7ed2e6d6-fb4d-4e31-b573-c9c14977ddd2" width="600" alt="Descripción alternativa 2">
</p>

Modifications were made in the following directories:
> #### edx-ora2
> - /openassessment/staffgrader/tests/test_list_staff_workflows.py
> - openassessment/staffgrader/serializers/submission_list.py
> - openassessment/staffgrader/staff_grader_mixin.py
> - openassessment/data.py
> #### edx-platform
> - lms/djangoapps/ora_staff_grader/serializers.py


<details>
  <summary>Click here! to see `/api/ora_staff_grader/initialize` output</summary>

```json
...
...
    "submissions": {
        "619b8fb2-ebc0-49ed-9b35-4700efb28f66": {
            "submissionUUID": "619b8fb2-ebc0-49ed-9b35-4700efb28f66",
            "username": "admin",
            "email": "admin@admin.com",
            "fullname": "Fernando Gonzalez",
            "teamName": null,
            "dateSubmitted": "2023-10-13 15:36:13.781179+00:00",
            "dateGraded": "2023-10-17 20:26:07.146547+00:00",
            "gradedBy": "admin",
            "gradeStatus": "graded",
            "lockStatus": "unlocked",
            "score": {
                "pointsEarned": 10,
                "pointsPossible": 10
            }
        }
    },
```
</details>

&nbsp;

## Testing

In order to test this, you can use the API platform Postman:

1. Get an auth token from /oauth2/access_token/

- **/api/ora_staff_grader/initialize:** params: oraLocation
-  **/api/ora_staff_grader/assessments/feedback:** params: oraLocation, submissionUUID, assessmentFilter = [`given`, `received`]



&nbsp;

This upgrade will consist of two PRs: one for ORA and the other for edx-platform. This is because the main serializer of the service resides in the platform. To test it, you'll need to fetch and set up the version of the platform with the serializer modification.

- **Platform PR link**: https://github.com/openedx/edx-platform/pull/33600
