### PR TITLE
feat: split peer assessments into peer and unused peer

### DIFF
--- a/openassessment/assessment/models/peer.py
+++ b/openassessment/assessment/models/peer.py
@@ -524,6 +524,16 @@ class PeerWorkflowItem(models.Model):
     scored = models.BooleanField(default=False)
 
     @classmethod
+    def _get_assessments(cls, submission_uuid, scored):
+        return Assessment.objects.filter(
+            pk__in=[
+                item.assessment.pk for item in PeerWorkflowItem.objects.filter(
+                    submission_uuid=submission_uuid, scored=scored
+                )
+            ]
+        )
+
+    @classmethod
     def get_scored_assessments(cls, submission_uuid):
         """
         Return all scored assessments for a given submission.
@@ -533,15 +543,22 @@ class PeerWorkflowItem(models.Model):
 
         Returns:
             QuerySet of Assessment objects.
+        """
+        return cls._get_assessments(submission_uuid, True)
+
+    @classmethod
+    def get_unscored_assessments(cls, submission_uuid):
+        """
+        Return all unscored assessments for a given submission.
+
+        Args:
+            submission_uuid (str): The UUID of the submission.
+
+        Returns:
+            QuerySet of Assessment objects.
 
         """
-        return Assessment.objects.filter(
-            pk__in=[
-                item.assessment.pk for item in PeerWorkflowItem.objects.filter(
-                    submission_uuid=submission_uuid, scored=True
-                )
-            ]
-        )
+        return cls._get_assessments(submission_uuid, False)
 
     @classmethod
     def get_bulk_scored_assessments(cls, submission_uuids):

--- a/openassessment/xblock/apis/assessments/peer_assessment_api.py
+++ b/openassessment/xblock/apis/assessments/peer_assessment_api.py
@@ -6,6 +6,8 @@ import logging
 from openassessment.assessment.errors import PeerAssessmentWorkflowError
 from openassessment.assessment.api import peer as peer_api
 from openassessment.assessment.errors.peer import PeerAssessmentInternalError, PeerAssessmentRequestError
+from openassessment.assessment.models.peer import PeerWorkflowItem
+from openassessment.assessment.serializers.base import serialize_assessments
 from openassessment.workflow.errors import AssessmentWorkflowError
 from openassessment.xblock.apis.assessments.errors import (
     ReviewerMustHaveSubmittedException,
@@ -37,6 +39,18 @@ class PeerAssessmentAPI(StepDataAPI):
     @property
     def assessments(self):
         return peer_api.get_assessments(self.submission_uuid)
+
+    @property
+    def scored_assessments(self):
+        return serialize_assessments(PeerWorkflowItem.get_scored_assessments(self.submission_uuid))
+
+    @property
+    def unscored_assessments(self):
+        return serialize_assessments(PeerWorkflowItem.get_unscored_assessments(self.submission_uuid))
+
+    @property
+    def peer_grade(self):
+        return self._block.grades_data.peer_score
 
     @property
     def continue_grading(self):

--- a/openassessment/xblock/apis/grades_api.py
+++ b/openassessment/xblock/apis/grades_api.py
@@ -47,7 +47,13 @@ class GradesAPI:
         }
         """
         submission_uuid = self._get_submission_uuid()
-        peer_requirements = self._block.workflow_requirements()["peer"]
+        if submission_uuid is None:
+            return None
+
+        peer_requirements = self._block.workflow_requirements().get('peer')
+        if peer_requirements is None:
+            return None
+
         course_settings = self._block.get_course_workflow_settings()
 
         peer_score = peer_api.get_score(

--- a/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
@@ -61,6 +61,32 @@ class AssessmentStepSerializer(Serializer):
     assessment = AssessmentDataSerializer(source="*")
 
 
+class PeerAssessmentsSerializer(Serializer):
+    """
+    Assessment step serializer for peer step
+    """
+
+    stepScore = AssessmentScoreSerializer(source='peer_grade')
+    assessments = AssessmentDataSerializer(
+        source="scored_assessments",
+        many=True,
+        allow_empty=True
+    )
+
+
+class UnweightedPeerAssessmentsSerializer(Serializer):
+    """
+    Assessment step serializer for peer step
+    """
+
+    stepScore = NullField(source='*')
+    assessments = AssessmentDataSerializer(
+        source="unscored_assessments",
+        many=True,
+        allow_empty=True
+    )
+
+
 class SubmissionFileSerializer(Serializer):
     fileUrl = URLField(source="file_key")
     fileDescription = CharField(source="file_description")
@@ -88,9 +114,8 @@ class AssessmentGradeSerializer(Serializer):
     effectiveAssessmentType = SerializerMethodField()
     self = AssessmentStepSerializer(source="self_assessment_data.assessment")
     staff = AssessmentStepSerializer(source="staff_assessment_data.assessment")
-    peer = AssessmentStepSerializer(
-        source="peer_assessment_data.assessments", many=True
-    )
+    peer = PeerAssessmentsSerializer(source="peer_assessment_data")
+    peerUnweighted = UnweightedPeerAssessmentsSerializer(source="peer_assessment_data")
 
     def get_effectiveAssessmentType(self, instance):  # pylint: disable=unused-argument
         """

--- a/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
@@ -88,7 +88,7 @@ class AssessmentGradeSerializer(Serializer):
     effectiveAssessmentType = SerializerMethodField()
     self = AssessmentStepSerializer(source="self_assessment_data.assessment")
     staff = AssessmentStepSerializer(source="staff_assessment_data.assessment")
-    peers = AssessmentStepSerializer(
+    peer = AssessmentStepSerializer(
         source="peer_assessment_data.assessments", many=True
     )
 

--- a/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
@@ -189,6 +189,7 @@ class TestPeerSplit(XBlockHandlerTestCase, SubmitAssessmentsMixin):
                 2,
             )
 
+        # Have the target learner submit one assessment so they can recieve a grade, and update their status
         self.create_peer_assessment(submission, 'Bernard', scorer_subs[0], self.ASSESSMENT, xblock.rubric_criteria, 2)
         workflow_api.update_from_assessments(
             submission['uuid'],

--- a/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
@@ -245,8 +245,7 @@ class TestAssessmentGradeSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixi
 
         # I get the appropriate response
         self.assertEqual(context["step"], data["effectiveAssessmentType"])
-        for i in range(len(data["peers"])):
-            peer = data["peers"][i]
+        for i, peer in enumerate(data["peer"]):
             serialize_peer = AssessmentStepSerializer(
                 xblock.api_data.peer_assessment_data().assessments[i], context=context
             ).data

--- a/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import patch
 
 from django.test import TestCase
+from openassessment.workflow import api as workflow_api
 from openassessment.fileupload.api import FileUpload
 from openassessment.xblock.test.base import (
     PEER_ASSESSMENTS,
@@ -157,6 +158,57 @@ class TestAssessmentResponseSerializer(XBlockHandlerTestCase, SubmissionTestMixi
         self.assertDictEqual(expected_response, data)
 
 
+class TestPeerSplit(XBlockHandlerTestCase, SubmitAssessmentsMixin):
+    ASSESSMENT = {
+        'options_selected': {'𝓒𝓸𝓷𝓬𝓲𝓼𝓮': 'ﻉซƈﻉɭɭﻉกՇ', 'Form': 'Fair'},
+        'criterion_feedback': {},
+        'overall_feedback': ""
+    }
+
+    @scenario("data/grade_scenario.xml", user_id="Bernard")
+    def test_scored_unscored(self, xblock):
+        student_item = xblock.get_student_item_dict()
+        submission = self.create_test_submission(
+            xblock, student_item=student_item, submission_text=self.SUBMISSION
+        )
+
+        other_learners = ['u1', 'u2', 'u3', 'u4']
+        # Create submissions from other users
+        scorer_subs = self.create_peer_submissions(
+            student_item, other_learners, self.SUBMISSION
+        )
+
+        # All four assess the target learner even though we only need two
+        for scorer_sub, scorer_name in list(zip(scorer_subs, other_learners)):
+            self.create_peer_assessment(
+                scorer_sub,
+                scorer_name,
+                submission,
+                self.ASSESSMENT,
+                xblock.rubric_criteria,
+                2,
+            )
+
+        self.create_peer_assessment(submission, 'Bernard', scorer_subs[0], self.ASSESSMENT, xblock.rubric_criteria, 2)
+        workflow_api.update_from_assessments(
+            submission['uuid'],
+            {'peer': {'must_be_graded_by': 2, 'must_grade': 1}},
+            {}
+        )
+
+        context = {"response": submission, "step": "peer"}
+
+        # When I load my response
+        data = AssessmentGradeSerializer(xblock.api_data, context=context).data
+
+        # I get the appropriate response
+        self.assertEqual(context["step"], data["effectiveAssessmentType"])
+        self.assertEqual(data["peer"]["stepScore"], {'earned': 5, 'possible': 6})
+        self.assertEqual(len(data["peer"]["assessments"]), 2)
+        self.assertIsNone(data["peerUnweighted"]["stepScore"])
+        self.assertEqual(len(data["peerUnweighted"]["assessments"]), 2)
+
+
 class TestAssessmentGradeSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixin):
     ASSESSMENT = {
         'options_selected': {'𝓒𝓸𝓷𝓬𝓲𝓼𝓮': 'ﻉซƈﻉɭɭﻉกՇ', 'Form': 'Fair'},
@@ -228,7 +280,7 @@ class TestAssessmentGradeSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixi
         graded_by = xblock.get_assessment_module("peer-assessment")["must_be_graded_by"]
         for scorer_sub, scorer_name, assessment in list(
             zip(scorer_subs, self.PEERS, PEER_ASSESSMENTS)
-        )[:-1]:
+        ):
             self.create_peer_assessment(
                 scorer_sub,
                 scorer_name,
@@ -245,12 +297,9 @@ class TestAssessmentGradeSerializer(XBlockHandlerTestCase, SubmitAssessmentsMixi
 
         # I get the appropriate response
         self.assertEqual(context["step"], data["effectiveAssessmentType"])
-        for i, peer in enumerate(data["peer"]):
-            serialize_peer = AssessmentStepSerializer(
-                xblock.api_data.peer_assessment_data().assessments[i], context=context
-            ).data
-            self.assertEqual(serialize_peer["stepScore"], peer["stepScore"])
-            self.assertEqual(serialize_peer["assessment"], serialize_peer["assessment"])
+        self.assertEqual(data["peer"], {'stepScore': None, 'assessments': []})
+        self.assertIsNone(data["peerUnweighted"]['stepScore'])
+        self.assertEqual(len(data["peerUnweighted"]['assessments']), len(self.PEERS))
 
     @scenario("data/grade_scenario.xml", user_id="Alan")
     def test_assessment_step_score(self, xblock):


### PR DESCRIPTION
**TL;DR -** Restructure peer assessment data

JIRA: [AU-1510](https://2u-internal.atlassian.net/browse/AU-1510)

**What changed?**

- key "peers" -> "peer"
- "peer" now only contains "scored" assessments
-  "peerUnweighted" added and contains "unscored" assessments

FYI: @openedx/content-aurora
