### PR TITLE
refactor: return assessment data on assess submit

### DIFF
--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -304,6 +304,13 @@ class MfeMixin:
         }
 
     def _assessment_submit_handler(self, data):
+        """
+        Args:
+        * AssessmentSubmitRequestData
+
+        Returns:
+        * Assessment Data
+        """
         serializer = AssessmentSubmitRequestSerializer(data=data)
         if not serializer.is_valid():
             raise OraApiException(400, error_codes.INCORRECT_PARAMETERS, serializer.errors)
@@ -348,6 +355,14 @@ class MfeMixin:
             raise OraApiException(400, error_codes.INVALID_STATE_TO_ASSESS, context) from e
         except (AssessmentError, AssessmentWorkflowError) as e:
             raise OraApiException(500, error_codes.INTERNAL_EXCEPTION, str(e)) from e
+
+        # Return assessment data for the frontend
+        # TODO - this should be updated to new assessment shape & serializer
+        return {
+            "optionsSelected": data["optionsSelected"],
+            "criterionFeedback": data["criterionFeedback"],
+            "overallFeedback": data["overallFeedback"],
+        }
 
     def _assessment_get_peer_handler(self):
         # Call get_peer_submission to grab a new peer submission

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -935,13 +935,22 @@ class AssessmentSubmitTest(MFEHandlersTestBase):
     )
     @scenario("data/basic_scenario.xml")
     def test_assess(self, xblock, step, expect_self, expect_training, expect_peer):
+        # Given a self / training / peer step
         with self.mock_workflow_status(step):
             with self.mock_assess_functions() as assess_mocks:
-                resp = self.request_assessment_submit(xblock)
+                # When I call the assessment endpoint
+                assessment = self.DEFAULT_ASSESSMENT_SUBMIT_VALUE
+                resp = self.request_assessment_submit(xblock, payload=assessment)
+
+        # Then I assess a response for the correct step
         assert resp.status_code == 200
         assert assess_mocks.self.called == expect_self
         assert assess_mocks.training.called == expect_training
         assert assess_mocks.peer.called == expect_peer
+
+        # And get the assessment data returned to the frontend
+        response_body = json.loads(resp.body)
+        self.assertDictEqual(response_body, assessment)
 
     @ddt.data(None, 'cancelled', 'waiting', 'self', 'training', 'done')
     @scenario("data/basic_scenario.xml")


### PR DESCRIPTION
**TL;DR -** Returns assessment data on submit

JIRA: [AU-1525](https://2u-internal.atlassian.net/browse/AU-1525)

**What changed?**

- When we call `assessment/submit` return the assessment data to the frontend.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
