### PR TITLE
refactor: update assessments formats

### DIFF
--- a/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
@@ -9,7 +9,6 @@ from rest_framework.serializers import (
     SerializerMethodField,
     URLField,
     Serializer,
-    DictField,
     BooleanField,
 )
 from openassessment.xblock.ui_mixins.mfe.serializer_utils import NullField
@@ -30,7 +29,9 @@ class AssessmentScoreSerializer(Serializer):
 
 class AssessmentCriterionSerializer(Serializer):
     """
-    returns:
+    Serialize assessment criterion values from DB representation to frontend data structure.
+
+    Returns:
     {
         selectedOption: (Int) Order of the selected option
         feedback: (String) Feedback for the selected option
@@ -42,10 +43,16 @@ class AssessmentCriterionSerializer(Serializer):
 
 class AssessmentDataSerializer(Serializer):
     """
-    Assessment data serializer
+    Serialize assessment data from DB representation to frontend data structure.
+
+    Returns:
+    {
+        criteria: [ AssessmentCriterionSerializer ]
+        overallFeedback: (String / Empty)
+    }
     """
     overallFeedback = CharField(source="feedback")
-    assessmentCriterions = AssessmentCriterionSerializer(source="parts", many=True)
+    criteria = AssessmentCriterionSerializer(source="parts", many=True)
 
 
 class AssessmentStepSerializer(Serializer):
@@ -167,9 +174,73 @@ class AssessmentResponseSerializer(Serializer):
         return [SubmissionFileSerializer(file).data for file in files]
 
 
-class AssessmentSubmitRequestSerializer(Serializer):
-    """" Serializer for validating request shape """
-    optionsSelected = DictField(child=CharField(), allow_empty=True)
-    criterionFeedback = DictField(child=CharField(), allow_empty=True)
+class MfeAssessmentCriterionSerializer(Serializer):
+    """
+    Frontend's view of rubric criterion values for an assessment
+
+    {
+        selectedOption: (Int) Order of the selected option
+        feedback: (String / Empty) Feedback for the selected option
+    }
+    """
+    selectedOption = IntegerField()
+    feedback = CharField()
+
+
+class MfeAssessmentDataSerializer(Serializer):
+    """
+    Frontend's view of Assessment Data.
+
+    criteria: [ MfeAssessmentCriterion ],
+    overallFeedback: (String / Empty) Feedback for the Assessment
+    """
+    criteria = MfeAssessmentCriterionSerializer(many=True)
     overallFeedback = CharField(allow_blank=True)
+
+
+class AssessmentSubmitRequestSerializer(MfeAssessmentDataSerializer):
+    """"
+    Serializer for validating request shape and unpacking data for assessment APIs.
+
+    Args: Data in the form
+    {
+        criteria: [
+            // Rubric criterion
+            {
+                selectedOption: (Int) Order of the selected option
+                feedback: (String / Empty) Feedback for the selected option
+            }
+            ...
+        ],  
+        overallFeedback: (String / Empty)
+    }
+    """
+
     continueGrading = BooleanField(required=False, default=False)
+
+    def to_legacy_format(self, xblock):
+        """
+        Converts given assessment format to format needed for submitting an assessment:
+
+        >>> options_selected = {"clarity": "Very clear", "precision": "Somewhat precise"}
+        >>> criterion_feedback = {"clarity": "I thought this essay was very clear."}
+        >>> feedback = "Your submission was thrilling."
+        """
+        options_selected = {}
+        criterion_feedback = {}
+
+        for i, criterion_data in enumerate(self.data['criteria']):
+
+            # Look up the name and value for each given rubric selection
+            criterion_name = xblock.rubric_criteria[i]['name']
+            selected_value = xblock.rubric_criteria[i]['options'][criterion_data['selectedOption']]['name']
+            options_selected[criterion_name] = selected_value
+
+            # Attach feedback for the criterion
+            criterion_feedback[criterion_name] = criterion_data['feedback']
+
+        return {
+            "options_selected": options_selected,
+            "criterion_feedback": criterion_feedback,
+            "feedback": self.data["overallFeedback"]
+        }

--- a/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
@@ -211,7 +211,7 @@ class AssessmentSubmitRequestSerializer(MfeAssessmentDataSerializer):
                 feedback: (String / Empty) Feedback for the selected option
             }
             ...
-        ],  
+        ],
         overallFeedback: (String / Empty)
     }
     """

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -25,7 +25,10 @@ from openassessment.xblock.apis.submissions.errors import (
     SubmitInternalError,
     UnsupportedFileTypeException
 )
-from openassessment.xblock.ui_mixins.mfe.assessment_serializers import AssessmentDataSerializer, AssessmentSubmitRequestSerializer, MfeAssessmentDataSerializer
+from openassessment.xblock.ui_mixins.mfe.assessment_serializers import (
+    AssessmentSubmitRequestSerializer,
+    MfeAssessmentDataSerializer,
+)
 from openassessment.xblock.ui_mixins.mfe.constants import error_codes, handler_suffixes
 from openassessment.xblock.ui_mixins.mfe.ora_config_serializer import OraBlockInfoSerializer
 from openassessment.xblock.ui_mixins.mfe.page_context_serializer import PageDataSerializer
@@ -348,7 +351,6 @@ class MfeMixin:
             raise OraApiException(400, error_codes.INVALID_STATE_TO_ASSESS, context) from e
         except (AssessmentError, AssessmentWorkflowError) as e:
             raise OraApiException(500, error_codes.INTERNAL_EXCEPTION, str(e)) from e
-
 
         # Return assessment data for the frontend
         return MfeAssessmentDataSerializer(data).data

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -25,7 +25,7 @@ from openassessment.xblock.apis.submissions.errors import (
     SubmitInternalError,
     UnsupportedFileTypeException
 )
-from openassessment.xblock.ui_mixins.mfe.assessment_serializers import AssessmentSubmitRequestSerializer
+from openassessment.xblock.ui_mixins.mfe.assessment_serializers import AssessmentDataSerializer, AssessmentSubmitRequestSerializer, MfeAssessmentDataSerializer
 from openassessment.xblock.ui_mixins.mfe.constants import error_codes, handler_suffixes
 from openassessment.xblock.ui_mixins.mfe.ora_config_serializer import OraBlockInfoSerializer
 from openassessment.xblock.ui_mixins.mfe.page_context_serializer import PageDataSerializer
@@ -307,30 +307,30 @@ class MfeMixin:
         serializer = AssessmentSubmitRequestSerializer(data=data)
         if not serializer.is_valid():
             raise OraApiException(400, error_codes.INCORRECT_PARAMETERS, serializer.errors)
-        data = serializer.validated_data
-        peer_data = self.peer_assessment_data(data['continueGrading'])
+        assessment_data = serializer.to_legacy_format(self)
+        peer_data = self.peer_assessment_data(serializer.data['continueGrading'])
         try:
             if peer_data.continue_grading or self.workflow_data.is_peer:
                 peer_assess(
-                    data['optionsSelected'],
-                    data['overallFeedback'],
-                    data['criterionFeedback'],
+                    assessment_data['options_selected'],
+                    assessment_data['feedback'],
+                    assessment_data['criterion_feedback'],
                     self.config_data,
                     self.workflow_data,
                     peer_data,
                 )
             elif self.workflow_data.is_self:
                 self_assess(
-                    data['optionsSelected'],
-                    data['criterionFeedback'],
-                    data['overallFeedback'],
+                    assessment_data['options_selected'],
+                    assessment_data['criterion_feedback'],
+                    assessment_data['feedback'],
                     self.config_data,
                     self.workflow_data,
                     self.self_data
                 )
             elif self.workflow_data.is_training:
                 corrections = training_assess(
-                    data['optionsSelected'],
+                    assessment_data['options_selected'],
                     self.config_data,
                     self.workflow_data,
                 )
@@ -348,6 +348,10 @@ class MfeMixin:
             raise OraApiException(400, error_codes.INVALID_STATE_TO_ASSESS, context) from e
         except (AssessmentError, AssessmentWorkflowError) as e:
             raise OraApiException(500, error_codes.INTERNAL_EXCEPTION, str(e)) from e
+
+
+        # Return assessment data for the frontend
+        return MfeAssessmentDataSerializer(data).data
 
     def _assessment_get_peer_handler(self):
         # Call get_peer_submission to grab a new peer submission

--- a/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_assessment_serializers.py
@@ -21,6 +21,7 @@ from openassessment.xblock.ui_mixins.mfe.assessment_serializers import (
     AssessmentScoreSerializer,
     AssessmentDataSerializer,
     AssessmentCriterionSerializer,
+    AssessmentSubmitRequestSerializer,
 )
 
 
@@ -347,4 +348,26 @@ class TestAssessmentDataSerializer(TestCase):
         }).data
 
         self.assertEqual(assessment_data["overallFeedback"], "Foo")
-        self.assertEqual(len(assessment_data["assessmentCriterions"]), 1)
+        self.assertEqual(len(assessment_data["criteria"]), 1)
+
+
+class TestAssessmentSubmitRequestSerializer(TestCase):
+    """
+    Test for AssessmentSubmitRequestSerializer
+    """
+
+    def test_assessment_data(self):
+        assessment_submit_request_data = AssessmentSubmitRequestSerializer({
+            "criteria": [
+                {
+                    "selectedOption": 3,
+                    "feedback": "Baz",
+                }
+            ],
+            "overallFeedback": "Foo",
+            "continueGrading": True,
+        }).data
+
+        self.assertEqual(assessment_submit_request_data["overallFeedback"], "Foo")
+        self.assertEqual(len(assessment_submit_request_data["criteria"]), 1)
+        self.assertTrue(assessment_submit_request_data["continueGrading"])

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -70,10 +70,23 @@ class MFEHandlersTestBase(XBlockHandlerTestCase):
     DEFAULT_DRAFT_VALUE = {'response': {'text_responses': ['hi']}}
     DEFAULT_SUBMIT_VALUE = {'response': {'text_responses': ['Hello World', 'Goodbye World']}}
     DEFAULT_DELETE_FILE_VALUE = {'fileIndex': 1}
+
     DEFAULT_ASSESSMENT_SUBMIT_VALUE = {
-        'optionsSelected': {'ferocity': 'fine', 'color': 'blue', 'element': 'volcano'},
-        'criterionFeedback': {'ferocity': 'rawr!', 'color': ':)', 'element': 'i prefer lead'},
-        'overallFeedback': 'i have no strong feelings',
+        "criteria": [
+            {
+                "selectedOption": 2,
+                "feedback": "rawr!",
+            },
+            {
+                "selectedOption": 0,
+                "feedback": ":)",
+            },
+            {
+                "selectedOption": 1,
+                "feedback": "i prefer lead",
+            }
+        ],
+        "overallFeedback": "i have no strong feelings",
     }
 
     def request_create_submission(self, xblock, payload=None):


### PR DESCRIPTION
**TL;DR -** Update assessments data format used to communicate with frontend.

JIRA: [AU-1528](https://2u-internal.atlassian.net/browse/AU-1528) and [AU-1525](https://2u-internal.atlassian.net/browse/AU-1525) (closes #2103 )

**What changed?**

Frontend now uses this format to communicate assessments data to / from the backend:
```
{
    criteria: [
        // Rubric criterion
        {
            selectedOption: (Int) Order of the selected option
            feedback: (String / Empty) Feedback for the selected option
        }
        ...
    ],  
    overallFeedback: (String / Empty)
}
```

Included supporting changes to convert this to the format used by the backend to submit an assessment.


**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
