### PR TITLE
chore: update jumpable step logic

### DIFF
--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -77,13 +77,10 @@ class MfeMixin:
 
         # Allow jumping to a specific step, within our allowed steps
         if jump_step:
-            jumpable_steps = ("submission", "peer", "grades")
-            if jump_step not in jumpable_steps:
-                raise JsonHandlerError(404, f"Invalid jump to step: {jump_step}")
             if self._can_jump_to_step(workflow_step, jump_step):
                 serializer_context.update({"jump_to_step": suffix})
             else:
-                raise JsonHandlerError(400, f"Cannot jump to step: {jump_step}")
+                return None
 
         # Determine which mode we are viewing in, since data comes from different sources
         # View submission, submitted or draft
@@ -102,10 +99,10 @@ class MfeMixin:
         step_name_mappings = {
             "submission": "submission",
             "peer": "peer",
-            "grades": "done"
+            "done": "done",
         }
 
-        workflow_step_to_jump_to = step_name_mappings[jump_step]
+        workflow_step_to_jump_to = step_name_mappings.get(jump_step, None)
 
         # Can always "jump" to submission
         if workflow_step_to_jump_to == "submission":

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -237,16 +237,13 @@ class GetLearnerDataRoutingTest(MFEHandlersTestBase, SubmissionTestMixin):
         # When I try to jump to a bad step
         response = self.request_get_learner_data(xblock, suffix="asdf")
 
-        # Then I get an error and don't return data
+        # Then I get None as response
+        self.assertIsNone(json.loads(response.body))
+
+        # And no serializer is called
         mock_serializer.assert_not_called()
 
-        expected_status = 404
-        self.assertEqual(expected_status, response.status_code)
-
-        expected_body = {'error': 'Invalid jump to step: asdf'}
-        self.assertDictEqual(expected_body, json.loads(response.body))
-
-    @ddt.data("peer", "grades")
+    @ddt.data("peer", "done")
     @patch("openassessment.xblock.ui_mixins.mfe.mixin.PageDataSerializer")
     @scenario("data/basic_scenario.xml")
     def test_jump_to_inaccessible_step(self, xblock, inaccessible_step, mock_serializer):
@@ -256,14 +253,11 @@ class GetLearnerDataRoutingTest(MFEHandlersTestBase, SubmissionTestMixin):
         # When I try to jump to a step I can't access
         response = self.request_get_learner_data(xblock, suffix=inaccessible_step)
 
-        # Then I get an error and don't return data
+        # Then I get None as response
+        self.assertIsNone(json.loads(response.body))
+
+        # And no serializer is called
         mock_serializer.assert_not_called()
-
-        expected_status = 400
-        self.assertEqual(expected_status, response.status_code)
-
-        expected_body = {'error': f'Cannot jump to step: {inaccessible_step}'}
-        self.assertDictEqual(expected_body, json.loads(response.body))
 
     @patch("openassessment.xblock.ui_mixins.mfe.mixin.PageDataSerializer")
     @scenario("data/basic_scenario.xml", user_id="Alice")


### PR DESCRIPTION
JIRA: https://2u-internal.atlassian.net/browse/AU-1540

**What changed?**

- Bad jump step should result in `None` instead of 400 error
- Update `grades` to `done` states
- Make `submission`, `peer` and `done` jumpable

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
