### PR TITLE
chore: respond step name for waiting

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.2'
+__version__ = '6.0.3'

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -252,17 +252,20 @@ class ProgressSerializer(Serializer):
         """Return the active step name"""
         if not instance.workflow_data.has_workflow or instance.workflow_data.is_cancelled:
             return "submission"
+        elif instance.workflow_data.is_waiting:
+            # If we are waiting, we are either waiting on a peer or a staff grade.
+            # Staff takes precidence, so if a required (not automatically inserted) staff
+            # step exists, we are considered to be in "staff". If there is a peer, we are
+            # considered to be in "peer"
+            workflow_requirements = instance.workflow_data.workflow_requirements
+            if "staff" in workflow_requirements and workflow_requirements["staff"]["required"]:
+                return "staff"
+            elif "peer" in workflow_requirements:
+                return "peer"
+            else:
+                raise UnknownActiveStepException("Workflow is in waiting but no staff or peer step is required.")
         else:
-            step_name = STEP_NAME_MAPPINGS[instance.workflow_data.status]
-            if step_name == "waiting":
-                workflow_requirements = instance.workflow_data.workflow_requirements
-                if 'staff' in workflow_requirements and workflow_requirements['staff']['required']:
-                    return "staff"
-                elif 'peer' in workflow_requirements:
-                    return "peer"
-                else:
-                    raise UnknownActiveStepException("Workflow is in waiting but no staff or peer step is required.")
-            return step_name
+            return STEP_NAME_MAPPINGS[instance.workflow_data.status]
 
 
 class PageDataSerializer(Serializer):

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -22,6 +22,10 @@ from openassessment.xblock.ui_mixins.mfe.submission_serializers import DraftResp
 from openassessment.xblock.ui_mixins.mfe.serializer_utils import STEP_NAME_MAPPINGS, CharListField
 
 
+class UnknownActiveStepException(Exception):
+    """Raised when we can't determine the active step"""
+
+
 class AssessmentScoreSerializer(Serializer):
     """
     Returns:
@@ -249,7 +253,16 @@ class ProgressSerializer(Serializer):
         if not instance.workflow_data.has_workflow or instance.workflow_data.is_cancelled:
             return "submission"
         else:
-            return STEP_NAME_MAPPINGS[instance.workflow_data.status]
+            step_name = STEP_NAME_MAPPINGS[instance.workflow_data.status]
+            if step_name == "waiting":
+                workflow_requirements = instance.workflow_data.workflow_requirements
+                if 'staff' in workflow_requirements and workflow_requirements['staff']['required']:
+                    return "staff"
+                elif 'peer' in workflow_requirements:
+                    return "peer"
+                else:
+                    raise UnknownActiveStepException("Workflow is in waiting but no staff or peer step is required.")
+            return step_name
 
 
 class PageDataSerializer(Serializer):

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -465,6 +465,19 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         self.assertNestedDictEquals(expected_data, progress_data)
 
     @scenario("data/peer_only_scenario.xml", user_id="Alan")
+    def test_peer_assessment__waiting(self, xblock):
+        # Given I am on the peer step and waiting for submissions
+        self.create_test_submission(xblock)
+        # xblock.workflow_data.workflow.set("status", "waiting")
+        xblock.workflow_data.workflow["status"] = "waiting"
+
+        # When I ask for progress
+        progress_data = ProgressSerializer(xblock).data
+
+        # Expect active step to be peer instead of waiting
+        self.assertEqual('peer', progress_data['activeStepName'])
+
+    @scenario("data/peer_only_scenario.xml", user_id="Alan")
     def test_peer_assessment__cancelled(self, xblock):
         # Given I am on the peer step and then get cancelled
         submission = self.create_test_submission(xblock)
@@ -594,6 +607,29 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         }
 
         self.assertNestedDictEquals(expected_data, progress_data)
+
+    @scenario('data/grade_scenario_self_staff.xml', user_id='Alan')
+    def test_self_staff_assessment__waiting(self, xblock):
+        # Given I am on the staff step and waiting for submissions
+        self.create_submission_and_assessments(xblock, 'submission_text', [], [], SELF_ASSESSMENT)
+        xblock.workflow_data.workflow['status'] = 'waiting'
+
+        # When I ask for progress
+        progress_data = ProgressSerializer(xblock).data
+
+        # Expect active step to be staff instead of waiting
+        self.assertEqual('staff', progress_data['activeStepName'])
+
+    @scenario('data/grade_scenario_self_staff_not_required.xml', user_id='Alan')
+    def test_self_staff_assessment__not_required(self, xblock):
+        # Given I am on the staff step and waiting for submissions
+        self.create_submission_and_assessments(xblock, 'submission_text', [], [], SELF_ASSESSMENT)
+
+        # When I ask for progress
+        progress_data = ProgressSerializer(xblock).data
+
+        # Expect active step to be staff instead of waiting
+        self.assertEqual('done', progress_data['activeStepName'])
 
     @skip
     @scenario("data/team_submission.xml", user_id="Alan")

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -14,6 +14,7 @@ from openassessment.fileupload.api import TeamFileDescriptor
 from openassessment.workflow.api import cancel_workflow
 from openassessment.xblock.apis.submissions.submissions_actions import create_team_submission
 from openassessment.xblock.apis.submissions.submissions_api import SubmissionAPI
+from openassessment.xblock.apis.workflow_api import WorkflowAPI
 from openassessment.xblock.test.base import (
     PEER_ASSESSMENTS,
     SELF_ASSESSMENT,
@@ -26,6 +27,7 @@ from openassessment.xblock.ui_mixins.mfe.page_context_serializer import (
     PageDataSerializer,
     ProgressSerializer,
     TeamInfoSerializer,
+    UnknownActiveStepException,
 )
 
 
@@ -464,12 +466,18 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
 
         self.assertNestedDictEquals(expected_data, progress_data)
 
-    @scenario("data/peer_only_scenario.xml", user_id="Alan")
+    @scenario("data/grade_scenario_peer_only.xml", user_id="Alan")
     def test_peer_assessment__waiting(self, xblock):
         # Given I am on the peer step and waiting for submissions
-        self.create_test_submission(xblock)
-        # xblock.workflow_data.workflow.set("status", "waiting")
-        xblock.workflow_data.workflow["status"] = "waiting"
+        self.create_submission_and_assessments(
+            xblock,
+            'submission_text',
+            self.PEERS,
+            PEER_ASSESSMENTS,
+            None,
+            waiting_for_peer=True
+        )
+        self.assertTrue(xblock.workflow_data.is_waiting)
 
         # When I ask for progress
         progress_data = ProgressSerializer(xblock).data
@@ -612,7 +620,7 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
     def test_self_staff_assessment__waiting(self, xblock):
         # Given I am on the staff step and waiting for submissions
         self.create_submission_and_assessments(xblock, 'submission_text', [], [], SELF_ASSESSMENT)
-        xblock.workflow_data.workflow['status'] = 'waiting'
+        self.assertTrue(xblock.workflow_data.is_waiting)
 
         # When I ask for progress
         progress_data = ProgressSerializer(xblock).data
@@ -620,16 +628,36 @@ class TestPageContextProgress(XBlockHandlerTestCase, SubmitAssessmentsMixin):
         # Expect active step to be staff instead of waiting
         self.assertEqual('staff', progress_data['activeStepName'])
 
-    @scenario('data/grade_scenario_self_staff_not_required.xml', user_id='Alan')
-    def test_self_staff_assessment__not_required(self, xblock):
-        # Given I am on the staff step and waiting for submissions
-        self.create_submission_and_assessments(xblock, 'submission_text', [], [], SELF_ASSESSMENT)
+    @scenario("data/grade_scenario_staff_peer.xml", user_id="Alan")
+    def test_peer_the_staff_assessment__waiting(self, xblock):
+        # Given I am waiting for both peer and staff assessments
+        self.create_submission_and_assessments(
+            xblock,
+            'submission_text',
+            self.PEERS,
+            PEER_ASSESSMENTS,
+            None,
+            waiting_for_peer=True
+        )
+        self.assertTrue(xblock.workflow_data.is_waiting)
 
         # When I ask for progress
         progress_data = ProgressSerializer(xblock).data
 
-        # Expect active step to be staff instead of waiting
-        self.assertEqual('done', progress_data['activeStepName'])
+        # Expect active step to be staff instead of waiting or peer
+        self.assertEqual('staff', progress_data['activeStepName'])
+
+    @scenario("data/self_only_scenario.xml", user_id="Alan")
+    def test_waiting_error(self, xblock):
+        # Given I am waiting when I shouldn't be able to be waiting
+        self.create_test_submission(xblock)
+        self.assertTrue(xblock.workflow_data.is_self)
+
+        with patch.object(WorkflowAPI, 'is_waiting', new_callable=PropertyMock(return_value=True)):
+            self.assertTrue(xblock.workflow_data.is_waiting)
+            # When I ask for progress
+            with self.assertRaises(UnknownActiveStepException):
+                ProgressSerializer(xblock).data  # pylint: disable=expression-not-assigned
 
     @skip
     @scenario("data/team_submission.xml", user_id="Alan")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** Handle waiting state

JIRA: https://2u-internal.atlassian.net/browse/AU-1542

**What changed?**

- On waiting with `staff` required, return staff
- On waiting with `peer`, return peer
- (Unit test) If staff not require, it should be done

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
