### PR TITLE
feat: disable ORA iframe hotjar integration for mobile

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.6'
+__version__ = '6.0.7'

--- a/openassessment/templates/openassessmentblock/base.html
+++ b/openassessment/templates/openassessmentblock/base.html
@@ -7,6 +7,8 @@
 -->
 <!-- Hotjar Tracking Code for https://www.edx.org/ -->
 <script>
+const isMobile = window.navigator.userAgent.includes("org.edx.mobile");
+if(!isMobile){
     (function(h,o,t,j,a,r){
         h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
         h._hjSettings={hjid:{{hotjar_site_id}},hjsv:6};
@@ -15,6 +17,7 @@
         r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
         a.appendChild(r);
     })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+}
 </script>
 <div class="wrapper wrapper--xblock wrapper--openassessment theme--basic">
     <!--Template for legacy ORA UI (will not co-exist with .ora-view)-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** ORA iframe requires separate  hotjar integration from existing parent (LMS) integration. However, this additional integration within iframe causes issue when rendered on mobile devices. This change is to disable ORA hotjar integration for mobile.    

JIRA: [AU-1471](https://2u-internal.atlassian.net/browse/AU-1471)

**What changed?**

- [ More in depth breakdown of changes ]
- [ Peripheral things that got changed ]
- [ etc... ]

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
