### PR TITLE
fix: BFF peer file URLS

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.9'
+__version__ = '6.0.10'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.9",
+  "version": "6.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.9",
+      "version": "6.0.10",
       "dependencies": {
         "@edx/frontend-build": "^6.1.1",
         "@edx/paragon": "^20.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.9",
+  "version": "6.0.10",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "^6.1.1",


### PR DESCRIPTION
**TL;DR -** [ A short summary of what this PR does and why ]

JIRA: [AU-1579](https://2u-internal.atlassian.net/browse/AU-1579)

**What changed?**

- Fixed URL generations for peer file uploads.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

Peer grading workflow.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
