### PR TITLE
refactor: reduce duplicate workflow update calls

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.27'
+__version__ = '6.0.28'

--- a/openassessment/workflow/api.py
+++ b/openassessment/workflow/api.py
@@ -195,7 +195,7 @@ def update_from_assessments(
     This is a little wonky from a REST, get-doesn't-change-state point of view,
     except that what's stored in the `AssessmentWorkflow` isn't the canonical
     true value -- it's just the most recently known state of it based on the
-    last known requirments. For now, we have to query for truth.
+    last known requirements. For now, we have to query for truth.
 
     Args:
         submission_uuid (str): Identifier for the submission the

--- a/openassessment/xblock/apis/assessments/student_training_api.py
+++ b/openassessment/xblock/apis/assessments/student_training_api.py
@@ -146,7 +146,7 @@ class StudentTrainingAPI(StepDataAPI):
         if not example:
             return (
                 {},
-                "No training example was returned fromt he API for student with Submission UUID {}".format(
+                "No training example was returned from the API for student with Submission UUID {}".format(
                     self._block.submission_uuid
                 ),
             )

--- a/openassessment/xblock/apis/grades_api.py
+++ b/openassessment/xblock/apis/grades_api.py
@@ -10,6 +10,7 @@ from openassessment.assessment.api import staff as staff_api
 class GradesAPI:
     def __init__(self, block):
         self._block = block
+        self.workflow_data = block.workflow_data
 
     def _get_submission_uuid(self):
         return self._block.submission_uuid
@@ -22,7 +23,7 @@ class GradesAPI:
 
         Returns: True if score was overridden by staff, False otherwise.
         """
-        workflow = self._block.get_workflow_info()
+        workflow = self.workflow_data.workflow
         score = workflow['score']
 
         complete = score is not None

--- a/openassessment/xblock/apis/ora_data_accessor.py
+++ b/openassessment/xblock/apis/ora_data_accessor.py
@@ -27,7 +27,7 @@ class ORADataAccessor:
 
     @property
     def workflow_data(self):
-        return WorkflowAPI(self._block)
+        return self._block.workflow_data
 
     @property
     def grades_data(self):

--- a/openassessment/xblock/apis/ora_data_accessor.py
+++ b/openassessment/xblock/apis/ora_data_accessor.py
@@ -2,7 +2,6 @@
 from openassessment.xblock.apis.grades_api import GradesAPI
 from openassessment.xblock.apis.ora_config_api import ORAConfigAPI
 from openassessment.xblock.apis.submissions.submissions_api import SubmissionAPI
-from openassessment.xblock.apis.workflow_api import WorkflowAPI
 from openassessment.xblock.apis.assessments.peer_assessment_api import PeerAssessmentAPI
 from openassessment.xblock.apis.assessments.self_assessment_api import SelfAssessmentAPI
 from openassessment.xblock.apis.assessments.staff_assessment_api import (

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -10,13 +10,28 @@ class WorkflowAPI:
     def __init__(self, block):
         self._block = block
         self.grades = self._block.grades_data
+        self._workflow = self._block.get_workflow_info()
 
     def get_workflow_info(self, submission_uuid=None):
-        return self._block.get_workflow_info(submission_uuid)
+        """
+        Update workflow info and return workflow for the submission.
+
+        NOTE - calls workflow update
+        """
+        self._workflow = self._block.get_workflow_info(submission_uuid)
+        return self._workflow
 
     @property
     def workflow(self):
-        return self.get_workflow_info()
+        """
+        Getter for workflow, used to keep us from updating workflow every time
+        we ask for info.
+
+        NOTE - when there isn't a workflow, this will try to refresh workflow.
+        """
+        if not self._workflow:
+            return self.get_workflow_info()
+        return self._workflow
 
     @property
     def has_workflow(self):
@@ -71,6 +86,11 @@ class WorkflowAPI:
                 return workflow_step_name
 
         return "done"
+
+    @property
+    def status(self):
+        if self.workflow:
+            return self.workflow.get("status")
 
     def has_reached_given_step(self, requested_step, current_workflow_step=None):
         """
@@ -141,10 +161,6 @@ class WorkflowAPI:
         return self._block.workflow_requirements()
 
     @property
-    def status(self):
-        return self.workflow.get("status")
-
-    @property
     def has_received_grade(self):
         return bool(self.workflow.get("score"))
 
@@ -158,6 +174,9 @@ class WorkflowAPI:
         return self._block.get_course_workflow_settings()
 
     def update_workflow_status(self, submission_uuid=None):
+        """
+        NOTE - calls workflow update.
+        """
         self._block.update_workflow_status(submission_uuid)
 
     def create_workflow(self, submission_uuid):

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -92,6 +92,7 @@ class WorkflowAPI:
     def status(self):
         if self.workflow:
             return self.workflow.get("status")
+        return None
 
     def has_reached_given_step(self, requested_step, current_workflow_step=None):
         """

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -9,7 +9,6 @@ from enum import Enum
 class WorkflowAPI:
     def __init__(self, block):
         self._block = block
-        self.grades = self._block.grades_data
         self._workflow = self._block.get_workflow_info()
 
     def get_workflow_info(self, submission_uuid=None):

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -176,9 +176,10 @@ class WorkflowAPI:
 
     def update_workflow_status(self, submission_uuid=None):
         """
-        NOTE - calls workflow update.
+        Update workflow and cache result
         """
         self._block.update_workflow_status(submission_uuid)
+        self._workflow = self.get_workflow_info()
 
     def create_workflow(self, submission_uuid):
         self._block.create_workflow(submission_uuid)

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -16,7 +16,9 @@ class WorkflowAPI:
         """
         Update workflow info and return workflow for the submission.
 
-        NOTE - calls workflow update
+        NOTE - Calls workflow update and caches result. When using new ORA
+        experience, this needs to be called instead of the base
+        get_workflow_info to update the cached value correctly.
         """
         self._workflow = self._block.get_workflow_info(submission_uuid)
         return self._workflow

--- a/openassessment/xblock/message_mixin.py
+++ b/openassessment/xblock/message_mixin.py
@@ -36,7 +36,7 @@ class MessageMixin:
         workflow = self.get_workflow_info()
         deadline_info = self._get_deadline_info()
 
-        # Finds the cannonical status of the workflow and the is_closed status of the problem
+        # Finds the canonical status of the workflow and the is_closed status of the problem
         status = workflow.get('status')
         status_details = workflow.get('status_details', {})
 

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -293,9 +293,14 @@ class OpenAssessmentBlock(
     def config_data(self):
         return ORAConfigAPI(self)
 
+    _workflow_data = None
+
     @property
     def workflow_data(self):
-        return WorkflowAPI(self)
+        # Initialize Workflow API only once
+        if not self._workflow_data:
+            self._workflow_data = WorkflowAPI(self)
+        return self._workflow_data
 
     @property
     def submission_data(self):

--- a/openassessment/xblock/team_workflow_mixin.py
+++ b/openassessment/xblock/team_workflow_mixin.py
@@ -107,7 +107,7 @@ class TeamWorkflowMixin:
         Returns cancellation information for a particular team submission.
 
         :param team_submission_uuid: The team_submission identifier associated with the
-        sumbission to return information for.
+        submission to return information for.
         :return: The cancellation information, or None if the team submission has
         not been cancelled.
         """

--- a/openassessment/xblock/test/base.py
+++ b/openassessment/xblock/test/base.py
@@ -387,9 +387,6 @@ class SubmissionTestMixin:
             xblock.workflow_data
         )
 
-        # update workflow
-        xblock.workflow_data.update_workflow_status()
-
         return submission
 
 

--- a/openassessment/xblock/test/base.py
+++ b/openassessment/xblock/test/base.py
@@ -359,7 +359,7 @@ class SubmissionTestMixin:
 
     def create_test_submission(self, xblock, student_item=None, submission_text=None):
         """
-        Helper for creating test submissions
+        Helper for creating test submissions. Also updates workflow status.
 
         Args:
         * xblock: The XBlock to create the submission under
@@ -379,7 +379,7 @@ class SubmissionTestMixin:
         if submission_text is None:
             submission_text = self.DEFAULT_TEST_SUBMISSION_TEXT
 
-        return submissions_actions.create_submission(
+        submission = submissions_actions.create_submission(
             student_item,
             submission_text,
             xblock.config_data,
@@ -387,6 +387,10 @@ class SubmissionTestMixin:
             xblock.workflow_data
         )
 
+        # update workflow
+        xblock.workflow_data.update_workflow_status()
+
+        return submission
 
 class SubmitAssessmentsMixin(SubmissionTestMixin):
     """
@@ -510,7 +514,7 @@ class SubmitAssessmentsMixin(SubmissionTestMixin):
 
     def submit_staff_assessment(self, xblock, submission, assessment):
         """
-        Submits a staff assessment for the specified submission.
+        Submits a staff assessment for the specified submission and refreshes workflow
 
         Args:
             xblock: The XBlock being assessed.
@@ -522,3 +526,6 @@ class SubmitAssessmentsMixin(SubmissionTestMixin):
         assessment['submission_uuid'] = submission['uuid']
         resp = self.request(xblock, 'staff_assess', json.dumps(assessment), response_format='json')
         self.assertTrue(resp['success'])
+
+        # refresh workflow status
+        xblock.workflow_data.update_workflow_status()

--- a/openassessment/xblock/test/base.py
+++ b/openassessment/xblock/test/base.py
@@ -392,6 +392,7 @@ class SubmissionTestMixin:
 
         return submission
 
+
 class SubmitAssessmentsMixin(SubmissionTestMixin):
     """
     A mixin for creating a submission and peer/self assessments so that the user can

--- a/openassessment/xblock/test/test_peer.py
+++ b/openassessment/xblock/test/test_peer.py
@@ -71,10 +71,10 @@ class TestPeerAssessment(XBlockHandlerTestCase, SubmissionTestMixin):
         reflect their done status with regards to the new requirements.
         """
         # Setup the peer grading scenario, using the default requirements
+        mock_requirements.return_value = {"peer": {"must_grade": 2, "must_be_graded_by": 2}}
         self._sally_and_hal_grade_each_other_helper(xblock)
 
         # Verify that Sally's workflow is not marked done, as the requirements are higher than 1.
-        mock_requirements.return_value = {"peer": {"must_grade": 2, "must_be_graded_by": 2}}
         workflow_info = xblock.get_workflow_info()
 
         # peer step is skipable. So we expect next status to be current status.

--- a/openassessment/xblock/test/test_staff.py
+++ b/openassessment/xblock/test/test_staff.py
@@ -267,7 +267,7 @@ class TestStaffAssessment(StaffAssessmentTestBase):
         assessment['submission_uuid'] = submission['uuid']
 
         with patch('openassessment.xblock.ui_mixins.legacy.views.staff.staff_api') as mock_api:
-            #  Simulate a error
+            #  Simulate an error
             mock_api.create_assessment.side_effect = staff_api.StaffAssessmentRequestError
             resp = self.request(xblock, 'staff_assess', json.dumps(STAFF_GOOD_ASSESSMENT), response_format='json')
             self.assertFalse(resp['success'])

--- a/openassessment/xblock/test/test_staff.py
+++ b/openassessment/xblock/test/test_staff.py
@@ -95,34 +95,30 @@ class TestStaffAssessmentRender(StaffAssessmentTestBase):
 
         # Verify that once the required step (self assessment) is done, the staff grade is shown as complete.
         status_details = {'peer': {'complete': True}}
-        self.set_mock_workflow_info(
-            xblock, workflow_status='done', status_details=status_details, submission_uuid=submission['uuid']
-        )
-        self._assert_path_and_context(
-            xblock,
-            {
-                'status_value': 'Complete',
-                'icon_class': 'fa-check',
-                'step_classes': 'is--showing',
-                'button_active': 'aria-expanded="true"',
-                'xblock_id': xblock.scope_ids.usage_id
-            }
-        )
+        with self.mock_workflow_status('done', status_details, submission["uuid"]):
+            self._assert_path_and_context(
+                xblock,
+                {
+                    'status_value': 'Complete',
+                    'icon_class': 'fa-check',
+                    'step_classes': 'is--showing',
+                    'button_active': 'aria-expanded="true"',
+                    'xblock_id': xblock.scope_ids.usage_id
+                }
+            )
 
         # Verify that if the problem is cancelled, the staff grade reflects this.
-        self.set_mock_workflow_info(
-            xblock, workflow_status='cancelled', status_details=status_details, submission_uuid=submission['uuid']
-        )
-        self._assert_path_and_context(
-            xblock,
-            {
-                'status_value': 'Cancelled',
-                'icon_class': 'fa-exclamation-triangle',
-                'button_active': 'disabled="disabled" aria-expanded="false"',
-                'step_classes': 'is--unavailable',
-                'xblock_id': xblock.scope_ids.usage_id
-            }
-        )
+        with self.mock_workflow_status('cancelled', status_details, submission['uuid']):
+            self._assert_path_and_context(
+                xblock,
+                {
+                    'status_value': 'Cancelled',
+                    'icon_class': 'fa-exclamation-triangle',
+                    'button_active': 'disabled="disabled" aria-expanded="false"',
+                    'step_classes': 'is--unavailable',
+                    'xblock_id': xblock.scope_ids.usage_id
+                }
+            )
 
     @scenario('data/grade_waiting_scenario.xml', user_id='Omar')
     def test_staff_grade_templates_no_peer(self, xblock):

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -269,7 +269,7 @@ class MfeMixin:
     def get_learner_submission_data(self):
         # TODO - Move this out of mixin, this is only here because it accesses
         # private functions in the mixin but should actually be in SubmissionAPI
-        workflow = self.get_team_workflow_info() if self.is_team_assignment() else self.get_workflow_info()
+        workflow = self.get_team_workflow_info() if self.is_team_assignment() else self.workflow_data.get_workflow_info()
         team_info, team_id = self.submission_data.get_submission_team_info(workflow)
         # If there is a submission, we do not need to load file upload data separately because files
         # will already have been gathered into the submission. If there is no submission, we need to

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -3,7 +3,6 @@ Data layer for ORA
 
 XBlock handlers which surface info about an ORA, instead of being tied to views.
 """
-from edx_django_utils.monitoring import function_trace
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 
@@ -68,13 +67,11 @@ MFE_STEP_TO_WORKFLOW_MAPPINGS = {
 
 class MfeMixin:
 
-    @function_trace("get_block_info")
     @XBlock.json_handler
     def get_block_info(self, data, suffix=""):  # pylint: disable=unused-argument
         block_info = OraBlockInfoSerializer(self)
         return block_info.data
 
-    @function_trace("get_learner_data")
     @XBlock.json_handler
     def get_learner_data(self, data, suffix=""):  # pylint: disable=unused-argument
         """
@@ -109,7 +106,6 @@ class MfeMixin:
         serializer_context["requested_step"] = requested_step
         return PageDataSerializer(self, context=serializer_context).data
 
-    @function_trace("submission_draft")
     def _submission_draft_handler(self, data):
         try:
             student_submission_data = data['response']['textResponses']
@@ -121,7 +117,6 @@ class MfeMixin:
         except DraftSaveException as e:
             raise OraApiException(500, error_codes.INTERNAL_EXCEPTION) from e
 
-    @function_trace("submission_create")
     def _submission_create_handler(self, data):
         from submissions import api as submission_api
         try:
@@ -155,7 +150,6 @@ class MfeMixin:
         else:
             raise OraApiException(404, error_codes.UNKNOWN_SUFFIX)
 
-    @function_trace("file_delete")
     def _file_delete_handler(self, data):
         try:
             file_index = int(data['fileIndex'])
@@ -182,7 +176,6 @@ class MfeMixin:
                 return file_entry
         return None
 
-    @function_trace("file_add")
     def _file_add_handler(self, data):
         serializer = AddFileRequestSerializer(data=data)
         if not serializer.is_valid():
@@ -228,7 +221,6 @@ class MfeMixin:
             'fileIndex': newly_added_file.index,
         }
 
-    @function_trace("file_callback")
     def _file_upload_callback_handler(self, data):
         serializer = FileUploadCallbackRequestSerializer(data=data)
         if not serializer.is_valid():
@@ -303,7 +295,6 @@ class MfeMixin:
             'file_data': file_data,
         }
 
-    @function_trace("assessment_submit")
     def _assessment_submit_handler(self, data):
         serializer = AssessmentSubmitRequestSerializer(data=data)
         if not serializer.is_valid():

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -269,8 +269,16 @@ class MfeMixin:
     def get_learner_submission_data(self):
         # TODO - Move this out of mixin, this is only here because it accesses
         # private functions in the mixin but should actually be in SubmissionAPI
-        workflow = self.get_team_workflow_info() if self.is_team_assignment() else self.workflow_data.get_workflow_info()
+
+        # Get team / individual workflow
+        workflow = None
+        if self.is_team_assignment():
+            workflow = self.get_team_workflow_info()
+        else:
+            workflow = self.workflow_data.get_workflow_info()
+
         team_info, team_id = self.submission_data.get_submission_team_info(workflow)
+
         # If there is a submission, we do not need to load file upload data separately because files
         # will already have been gathered into the submission. If there is no submission, we need to
         # load file data from learner state and the SharedUpload db model

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.27",
+  "version": "6.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.27",
+      "version": "6.0.28",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@openedx/paragon": "^21.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.27",
+  "version": "6.0.28",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** Reduce the number of duplicate workflow updates from common ORA data load patterns.

**What changed?**

Asking for a `workflow` from the `WorkflowAPI` called `get_workflow_info` which would update the workflow before fetching workflow information. Since many of the other fields on `WorkflowAPI` referenced that `workflow` property, asking for **any** of this information would cause additional refreshes of the workflow, needlessly.

Loading the ORA MFE, I was averaging over 20 workflow refreshes and a local load time of ~500ms.

This PR begins to add a few refactors aimed at reducing how frequently we call a workflow update to (ideally) once per user action, calling cached workflow info any time between those actions.

- Memoize `workflow` property on `WorkflowAPI` to return last-fetched workflow data instead of re-updating/fetching.
- Load `workflow` on `WorkflowAPI` init (e.g. XBlock / MFE load)
- Reduce the number of times `WorkflowAPI` is initialized by memoizing `workflow_data` on `OpenassessmentBlock` and `ORADataAccessor` on fetch / update.
- Attempt to re-fetch `workflow` when a workflow is not present (this is not ideal from a performance standpoint but appears to fix a large number of tests).

**Other changes:**
- Remove unused `grades` accessor from `WorkflowAPI`.
- Updated some mocking to fix tests which relied on old call structure.
- Fixed a handful of typos I encountered along the way.

**NOTE** that this does mean it is more possible to get stale workflows so it is up to each endpoint / caller to determine if they need to refresh the workflow state on a per-action basis.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

- Unit testing
- Smoke test suites

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
