### PR TITLE
fix: BFF fix peer get

### DIFF
--- a/openassessment/xblock/ui_mixins/mfe/constants/handler_suffixes.py
+++ b/openassessment/xblock/ui_mixins/mfe/constants/handler_suffixes.py
@@ -5,7 +5,6 @@ SUBMISSION_SUBMIT = 'submit'
 FILE_ADD = 'add'
 FILE_DELETE = 'delete'
 ASSESSMENT_SUBMIT = 'submit'
-ASSESSMENT_GET_PEER = 'get_peer'
 FILE_UPLOAD_CALLBACK = 'upload_response'
 
 STEP_SUFFIXES = ("submission", "peer", "studentTraining", "self", "staff", "done")

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -334,28 +334,9 @@ class MfeMixin:
         # Return assessment data for the frontend
         return MfeAssessmentDataSerializer(data).data
 
-    def _assessment_get_peer_handler(self):
-
-        # Raise an exception if we don't have a peer step
-        if "peer-assessment" not in self.assessment_steps:
-            raise OraApiException(400, error_codes.INACCESSIBLE_STEP, error_context="No peer step for ORA")
-
-        # Call get_peer_submission to grab a new peer submission
-        self.peer_assessment_data().get_peer_submission()
-
-        # Then, just return page data
-        serializer_context = {
-            "view": "assessment",
-            "step": "peer",
-        }
-        page_context = PageDataSerializer(self, context=serializer_context)
-        return page_context.data
-
     @XBlock.json_handler
     def assessment(self, data, suffix=""):
         if suffix == handler_suffixes.ASSESSMENT_SUBMIT:
             return self._assessment_submit_handler(data)
-        elif suffix == handler_suffixes.ASSESSMENT_GET_PEER:
-            return self._assessment_get_peer_handler()
         else:
             raise OraApiException(404, error_codes.UNKNOWN_SUFFIX)

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -343,15 +343,7 @@ class PageDataSerializer(Serializer):
 
         # Peer
         elif requested_step == "peer":
-
-            # If this is the step we're on (not continued grading), get a new submission to assess
-            if current_workflow_step == "peer":
-                response = instance.peer_assessment_data().get_peer_submission()
-
-            # We're revisiting the peer step, get me my active assessment, if I have one in progress...
-            # Otherwise, we're using a separate endpoint to request extra peer submissions to grade.
-            else:
-                response = instance.peer_assessment_data().get_active_assessment_submission()
+            response = instance.peer_assessment_data().get_peer_submission()
 
         # Self / Done - Return your response to view / assess
         elif requested_step in ("self", "done"):

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -161,15 +161,6 @@ class MFEHandlersTestBase(XBlockHandlerTestCase):
             response_format='response'
         )
 
-    def request_assessment_get_peer(self, xblock):
-        return super().request(
-            xblock,
-            'assessment',
-            '{}',
-            suffix=handler_suffixes.ASSESSMENT_GET_PEER,
-            response_format='response'
-        )
-
 
 def assert_error_response(response, status_code, error_code, context=''):
     assert response.status_code == status_code
@@ -1003,16 +994,3 @@ class AssessmentSubmitTest(MFEHandlersTestBase):
                 resp = self.request_assessment_submit(xblock)
 
         assert_error_response(resp, 400, error_codes.TRAINING_ANSWER_INCORRECT, corrections)
-
-
-class AssessmentGetPeerTest(MFEHandlersTestBase):
-
-    @scenario("data/basic_scenario.xml")
-    def test_get_peer(self, xblock):
-        with patch.object(PeerAssessmentAPI, 'get_peer_submission') as mock_get_peer:
-            with patch('openassessment.xblock.ui_mixins.mfe.mixin.PageDataSerializer') as mock_serializer:
-                mock_serializer().data = str(uuid4())
-                resp = self.request_assessment_get_peer(xblock)
-        assert resp.status_code == 200
-        assert resp.json == mock_serializer().data
-        mock_get_peer.assert_called()

--- a/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_page_context_serializer.py
@@ -181,19 +181,6 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         expected_response = {}
         self.assertDictEqual(expected_response, response_data)
 
-    @scenario("data/staff_grade_scenario.xml", user_id="Alan")
-    def test_waiting_response(self, xblock):
-        # Given I'm on the staff step
-        self.create_test_submission(xblock)
-
-        # When I load my response
-        self.context = {"requested_step": "peer", "current_workflow_step": "waiting"}
-        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
-
-        # Then I get an empty object
-        expected_response = {}
-        self.assertDictEqual(expected_response, response_data)
-
     @scenario("data/self_assessment_scenario.xml", user_id="Alan")
     def test_done_response(self, xblock):
         # Given I'm on the done step
@@ -212,32 +199,21 @@ class TestPageDataSerializerAssessment(XBlockHandlerTestCase, SubmitAssessmentsM
         }
         self.assertDictEqual(expected_response, response_data)
 
-    @scenario("data/grade_scenario_peer_only.xml", user_id="Bernard")
-    def test_jump_to_peer_response__no_active_assessment(self, xblock):
-        student_item = xblock.get_student_item_dict()
+    @scenario("data/grade_scenario_peer_only.xml", user_id="Alan")
+    def test_jump_to_peer_not_available(self, xblock):
+        # Given I'm past the peer step
+        self.create_test_submission(xblock)
 
-        # Given responses available for peer grading
-        other_student_item = deepcopy(student_item)
-        other_student_item["student_id"] = "Joan"
-        other_text_responses = ["Answer 1", "Answer 2"]
-        self.create_test_submission(
-            xblock,
-            student_item=other_student_item,
-            submission_text=other_text_responses,
-        )
+        # When I ask for a peer response, but there are none available
+        self.context = {"requested_step": "peer", "current_workflow_step": "waiting"}
+        response_data = PageDataSerializer(xblock, context=self.context).data["response"]
 
-        # ... and I have completed the peer step of an ORA
-        self.create_submission_and_assessments(xblock, self.SUBMISSION, self.PEERS, PEER_ASSESSMENTS, None)
-
-        # When I try to jump back to that step
-        self.context = {"requested_step": "peer", "current_workflow_step": "done"}
-        response_data = PageDataSerializer(xblock, context=self.context).data
-
-        # I receive an empty response because I have not yet requested a submission to assess
-        self.assertDictEqual({}, response_data["response"])
+        # Then I get an empty object
+        expected_response = {}
+        self.assertDictEqual(expected_response, response_data)
 
     @scenario("data/grade_scenario_peer_only.xml", user_id="Bernard")
-    def test_jump_to_peer_response__active_assessment(self, xblock):
+    def test_jump_to_peer_available(self, xblock):
         student_item = xblock.get_student_item_dict()
 
         # Given responses available for peer grading


### PR DESCRIPTION
**What changed?**

- Always try to get peer response when visiting the peer step.
- Remove now unused `get_peer` endpoint to 
- Update tests.
- Bump ORA to 

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

- TODO

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
