### PR TITLE
feat: disable new ORA experience for leaderboards

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.13'
+__version__ = '6.0.14'

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -658,6 +658,7 @@ class OpenAssessmentBlock(
         Unsupported use-cases:
         1) Team assignments
         2) Assignments with reordered assessment steps
+        3) ORAs with leaderboards
 
         Returns:
         - False if we are in one of these unsupported configurations.
@@ -670,6 +671,10 @@ class OpenAssessmentBlock(
 
         # Assessment step reordering is currently unsupported
         if not self.uses_default_assessment_order:
+            return False
+
+        # We currently don't support leaderboards
+        if self.leaderboard_show != 0:
             return False
 
         return True

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -723,6 +723,18 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         # Then they are unsupported for team assignments
         self.assertFalse(xblock.mfe_views_supported)
 
+    @ddt.unpack
+    @ddt.data((0, True), (5, False))
+    @patch.object(openassessmentblock.OpenAssessmentBlock, 'leaderboard_show', new_callable=PropertyMock)
+    @scenario('data/simple_self_staff_scenario.xml')
+    def test_mfe_views_supported__leaderboard(self, xblock, mock_value, expected_supported, mock_leaderboard_show):
+        # Given I'm on / not on an ORA with a leaderboard
+        mock_leaderboard_show.return_value = mock_value
+
+        # When I see if MFE views are supported
+        # Then they are unsupported for ORAs with leaderboards
+        self.assertEqual(xblock.mfe_views_supported, expected_supported)
+
 
 class TestDates(XBlockHandlerTestCase):
     """ Test Assessment Dates. """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.11",
+  "version": "6.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.11",
+      "version": "6.0.14",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@edx/paragon": "^20.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** disables ORA experience when leaderboards are enabled (not currently supported).

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

1. Go to Studio
2. Create / edit an ORA
3. Set "Top Responses" to a non-zero value.
4. Verify that we use the legacy ORA experience.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
