### PR TITLE
feat: new ora disable on latex

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.14'
+__version__ = '6.0.15'

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -659,6 +659,7 @@ class OpenAssessmentBlock(
         1) Team assignments
         2) Assignments with reordered assessment steps
         3) ORAs with leaderboards
+        4) ORAs with LaTeX previews enabled
 
         Returns:
         - False if we are in one of these unsupported configurations.
@@ -675,6 +676,10 @@ class OpenAssessmentBlock(
 
         # We currently don't support leaderboards
         if self.leaderboard_show != 0:
+            return False
+
+        # LaTeX previews not enabled yet
+        if self.allow_latex:
             return False
 
         return True

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -735,6 +735,18 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         # Then they are unsupported for ORAs with leaderboards
         self.assertEqual(xblock.mfe_views_supported, expected_supported)
 
+    @ddt.unpack
+    @ddt.data((True, False), (False, True))
+    @patch.object(openassessmentblock.OpenAssessmentBlock, 'allow_latex', new_callable=PropertyMock)
+    @scenario('data/simple_self_staff_scenario.xml')
+    def test_mfe_views_supported__latex(self, xblock, mock_value, expected_supported, mock_allow_latex):
+        # Given I'm on / not on an ORA with a leaderboard
+        mock_allow_latex.return_value = mock_value
+
+        # When I see if MFE views are supported
+        # Then they are unsupported for ORAs with leaderboards
+        self.assertEqual(xblock.mfe_views_supported, expected_supported)
+
 
 class TestDates(XBlockHandlerTestCase):
     """ Test Assessment Dates. """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.14",
+  "version": "6.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.14",
+      "version": "6.0.15",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@edx/paragon": "^20.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.14",
+  "version": "6.0.15",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** Disables new ORA experience when LaTeX previews are enabled, since this is currently unsupported on the frontend.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
