### PR TITLE
fix: serialization of unfinished, unscored peer assignments

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.15'
+__version__ = '6.0.16'

--- a/openassessment/assessment/models/peer.py
+++ b/openassessment/assessment/models/peer.py
@@ -528,7 +528,7 @@ class PeerWorkflowItem(models.Model):
         return Assessment.objects.filter(
             pk__in=[
                 item.assessment.pk for item in PeerWorkflowItem.objects.filter(
-                    submission_uuid=submission_uuid, scored=scored
+                    submission_uuid=submission_uuid, scored=scored, assessment__isnull=False
                 )
             ]
         )

--- a/openassessment/assessment/test/test_peer.py
+++ b/openassessment/assessment/test/test_peer.py
@@ -1243,6 +1243,19 @@ class TestPeerApi(CacheResetTest):
             tim_answer, __ = self._create_student_and_submission("Tim", "Tim's answer", MONDAY)
             peer_api.get_assessment_feedback(tim_answer['uuid'])
 
+    def test_get_assessments_null(self):
+        # Test to fix serialization of incomplete, unscored assessments
+
+        # Tim & Buffy submit
+        tim_answer, _ = self._create_student_and_submission("Tim", "Tim's answer")
+        buffy_answer, _ = self._create_student_and_submission("Buffy", "Buffy's answer")
+
+        # Buffy starts but does not finish assessing Tim's answer
+        peer_api.get_submission_to_assess(buffy_answer['uuid'], REQUIRED_GRADED_BY)
+
+        # Tim gets unscored assessments, this used to throw an error
+        PeerWorkflowItem.get_unscored_assessments(tim_answer["uuid"])
+
     @patch('openassessment.assessment.models.peer.PeerWorkflowItem.get_scored_assessments')
     def test_set_assessment_feedback_error(self, mock_filter):
         with raises(peer_api.PeerAssessmentInternalError):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.15",
+  "version": "6.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.15",
+      "version": "6.0.16",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@edx/paragon": "^20.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.15",
+  "version": "6.0.16",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** Fixes issue serializing grades for unfinished, unscored peer assignments.

**What changed?**

We were running into the issue below when trying to get grade data for peers in new ORA experience:

```
AttributeError: Got AttributeError when attempting to get a value for field `assessments` on serializer `UnweightedPeerAssessmentsSerializer`. The serializer field might be named incorrectly and not match any attribute or key on the `PeerAssessmentAPI` instance. Original exception text was: 'NoneType' object has no attribute 'pk'.
```

It was determined that this came from serializing unscored peer workflow items that didn't have an associated assessment (unfinished assessment) based on how we are doing that lookup. Added a `null` check to the filter to remove these from the resopnse.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

See UAT tests.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
