### PR TITLE
feat: serial workflow advance fix

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.20'
+__version__ = '6.0.21'

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -64,10 +64,10 @@ class WorkflowAPI:
 
         for next_step in [step["name"] for step in step_order]:
             workflow_step_name = WorkflowStep(next_step).workflow_step_name
-            if (
-                status_details[workflow_step_name].get("complete", False) is False or
-                staticmethod[workflow_step_name].get("graded", False) is False
-            ):
+            step_complete = status_details[workflow_step_name].get("complete", False)
+            step_graded = status_details[workflow_step_name].get("graded", False)
+
+            if step_complete is False or step_graded is False:
                 return workflow_step_name
 
         return "done"

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -65,8 +65,8 @@ class WorkflowAPI:
         for next_step in [step["name"] for step in step_order]:
             workflow_step_name = WorkflowStep(next_step).workflow_step_name
             if (
-                status_details[workflow_step_name].get("complete", False) is False
-                or staticmethod[workflow_step_name].get("graded", False) is False
+                status_details[workflow_step_name].get("complete", False) is False or
+                staticmethod[workflow_step_name].get("graded", False) is False
             ):
                 return workflow_step_name
 

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -64,7 +64,8 @@ class WorkflowAPI:
 
         for next_step in [step['name'] for step in step_order]:
             workflow_step_name = WorkflowStep(next_step).workflow_step_name
-            if status_details[workflow_step_name].get('complete', False) is False:
+            if status_details[workflow_step_name].get('complete', False) is False \
+                or staticmethod[workflow_step_name].get('graded', False) is False:
                 return workflow_step_name
 
         return "done"

--- a/openassessment/xblock/apis/workflow_api.py
+++ b/openassessment/xblock/apis/workflow_api.py
@@ -62,10 +62,12 @@ class WorkflowAPI:
         if status in ("done", "cancelled"):
             return status
 
-        for next_step in [step['name'] for step in step_order]:
+        for next_step in [step["name"] for step in step_order]:
             workflow_step_name = WorkflowStep(next_step).workflow_step_name
-            if status_details[workflow_step_name].get('complete', False) is False \
-                or staticmethod[workflow_step_name].get('graded', False) is False:
+            if (
+                status_details[workflow_step_name].get("complete", False) is False
+                or staticmethod[workflow_step_name].get("graded", False) is False
+            ):
                 return workflow_step_name
 
         return "done"
@@ -144,7 +146,7 @@ class WorkflowAPI:
 
     @property
     def has_received_grade(self):
-        return bool(self.workflow.get('score'))
+        return bool(self.workflow.get("score"))
 
     def get_workflow_status_counts(self):
         return self._block.get_workflow_status_counts()
@@ -212,7 +214,7 @@ class WorkflowStep:
 
     @property
     def assessment_module_name(self):
-        """ Get the assessment module name for the step """
+        """Get the assessment module name for the step"""
         for assessment_step, canonical_step in self._assessment_module_mappings.items():
             if canonical_step == self.canonical_step:
                 return assessment_step
@@ -220,7 +222,7 @@ class WorkflowStep:
 
     @property
     def workflow_step_name(self):
-        """ Get the workflow step name for the step """
+        """Get the workflow step name for the step"""
         for workflow_step, canonical_step in self._workflow_step_mappings.items():
             if canonical_step == self.canonical_step:
                 return workflow_step

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.19",
+  "version": "6.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.19",
+      "version": "6.0.21",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@openedx/paragon": "^21.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.20",
+  "version": "6.0.21",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** Check both `graded` and `complete` workflow status indicators to confirm we've completed a workflow step instead of just `complete`.

**What changed?**

In the new ORA UI we serially progress through steps, blocking movement forward to a subsequent step until all requirements are met for the current step. This blocks us from determining workflow status directly (as previously, we would jump forward as far as you are able to view, skipping peer if it was followed by an additional step) and requires us to manually determine how far we have progressed.

Previous checks incorrectly determined this by only checking `complete` (whether *you* have finished your required work on a step) instead of also checking `graded` (whether you have received required external grades e.g. from peers).

This adds the additional check that both `complete` and `graded` must be `True` for a step to be considered finished.

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
