### PR TITLE
chore: remove disable on assessment out of order

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.22'
+__version__ = '6.0.23'

--- a/openassessment/templates/legacy/self/oa_self_assessment.html
+++ b/openassessment/templates/legacy/self/oa_self_assessment.html
@@ -3,7 +3,7 @@
 {% spaceless %}
 {% if show_survey %}
     <div id="openassessment_hotjar"></div>
-    <script>
+    <script type="text/javascript">
          // check to see if hotjar is available, then trigger hotjar event
         const hasWindow = typeof window !== 'undefined';
         if (hasWindow && window.hj) {

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -634,23 +634,6 @@ class OpenAssessmentBlock(
         )
 
     @property
-    def uses_default_assessment_order(self):
-        """
-        Determine if our steps have been reordered (omission of steps is fine)
-        """
-        mfe_supported_step_ordering = ['student-training', 'self-assessment', 'peer-assessment', 'staff-assessment']
-
-        last_step_index = 0
-        for assessment_step in self.assessment_steps:
-            step_index = mfe_supported_step_ordering.index(assessment_step)
-
-            if step_index < last_step_index:
-                return False
-            last_step_index = step_index
-
-        return True
-
-    @property
     def mfe_views_supported(self):
         """
         Currently, there are some unsupported use-cases for ORA MFE views.
@@ -676,10 +659,6 @@ class OpenAssessmentBlock(
 
         # LaTeX previews not enabled yet
         if self.allow_latex:
-            return False
-
-        # Assessment step reordering is currently unsupported
-        if not self.uses_default_assessment_order:
             return False
 
         return True

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -743,9 +743,7 @@ class TestOpenAssessment(XBlockHandlerTestCase):
     @scenario('data/assessment_steps_reordered.xml')
     def test_mfe_views_supported__rearranged_steps(self, xblock):
         # Given this ORA has rearranged our assessment steps
-        # When I see if MFE views are supported
-        # Then they are unsupported for team assignments
-        self.assertFalse(xblock.mfe_views_supported)
+        self.assertTrue(xblock.mfe_views_supported)
 
 
 class TestDates(XBlockHandlerTestCase):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.22",
+  "version": "6.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.22",
+      "version": "6.0.23",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@openedx/paragon": "^21.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.22",
+  "version": "6.0.23",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** workflow steps should work even it is out of order

JIRA: https://2u-internal.atlassian.net/browse/AU-1603

**NOTE** you can only re-arrange self and practice stage. ORA protect us from saving any other order.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
