### PR TITLE
fix: bff handle feedback only criteria

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.21'
+__version__ = '6.0.22'

--- a/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
+++ b/openassessment/xblock/ui_mixins/mfe/assessment_serializers.py
@@ -37,7 +37,7 @@ class AssessmentCriterionSerializer(Serializer):
         feedback: (String) Feedback for the selected option
     }
     """
-    selectedOption = IntegerField(source="option.order_num")
+    selectedOption = IntegerField(source="option.order_num", allow_null=True)
     feedback = CharField()
 
 
@@ -190,7 +190,7 @@ class MfeAssessmentCriterionSerializer(Serializer):
         feedback: (String / Empty) Feedback for the selected option
     }
     """
-    selectedOption = IntegerField()
+    selectedOption = IntegerField(allow_null=True)
     feedback = CharField(allow_blank=True, allow_null=True)
 
 
@@ -241,8 +241,13 @@ class AssessmentSubmitRequestSerializer(MfeAssessmentDataSerializer):
 
             # Look up the name and value for each given rubric selection
             criterion_name = xblock.rubric_criteria[i]['name']
-            selected_value = xblock.rubric_criteria[i]['options'][criterion_data['selectedOption']]['name']
-            options_selected[criterion_name] = selected_value
+
+            # For feedback-only criteria, there are no options
+            if len(xblock.rubric_criteria[i]['options']) > 0:
+
+                # Otherwise, get the value of the selected option
+                selected_value = xblock.rubric_criteria[i]['options'][criterion_data['selectedOption']]['name']
+                options_selected[criterion_name] = selected_value
 
             # Attach feedback for the criterion
             criterion_feedback[criterion_name] = criterion_data['feedback']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.21",
+  "version": "6.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.21",
+      "version": "6.0.22",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@openedx/paragon": "^21.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.21",
+  "version": "6.0.22",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** Fix BFF handling of feedback-only rubric criteria.

JIRA: [AU-1646](https://2u-internal.atlassian.net/browse/AU-1646)

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

1. Create an ORA.
2. Edit the ORA to remove all rubric options from one / all of the rubric criteria.
3. Save.
4. Submit a response & progress to end of grading workflow.
5. Verify nothing breaks.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
