### PR TITLE
fix: make sure we're assessing the right submission

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.24'
+__version__ = '6.0.25'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.24",
+  "version": "6.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.24",
+  "version": "6.0.25",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** 

```
Old code:

-Pass the current submission uuid along with the assessment info
-Backend calls get_peer_whatever which discards "old" PeerWorkflowItem and grabs a new one
-passed old uuid doesn't match new uuid and assess fails

We don't pass a submission uuid back to the mfe view. What I think will happen now is:

-Call peer_assess with assessment for old submission
-Old peer workflow item is discarded and we grab a new one
-apply assessment for old submission to new submission

```

To fix, when we are peer-assessing, rather than grabbing a new submission, just check to see if we don't have one.
If we don't, rase the error.

This solves 90% of the problem but there's still an edge case that is addressed by https://2u-internal.atlassian.net/browse/AU-1653

JIRA: [AU-1647](https://2u-internal.atlassian.net/browse/AU-1647)

FYI: @openedx/content-aurora
