### PR TITLE
fix: block submission and assessments when steps closed

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.30'
+__version__ = '6.0.31'

--- a/openassessment/staffgrader/staff_grader_mixin.py
+++ b/openassessment/staffgrader/staff_grader_mixin.py
@@ -459,7 +459,7 @@ class StaffGraderMixin:
                 data['overall_feedback'],
                 data.get('assess_type', 'regrade'),
                 self.config_data,
-                self.staff_data,
+                self.staff_assessment_data,
             )
             if self.is_team_assignment():
                 do_team_staff_assessment(*args, team_submission_uuid=submission_uuid)

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -310,11 +310,11 @@ class OpenAssessmentBlock(
         return PeerAssessmentAPI(self, continue_grading)
 
     @property
-    def self_data(self):
+    def self_assessment_data(self):
         return SelfAssessmentAPI(self)
 
     @property
-    def staff_data(self):
+    def staff_assessment_data(self):
         return StaffAssessmentAPI(self)
 
     @property

--- a/openassessment/xblock/ui_mixins/legacy/handlers_mixin.py
+++ b/openassessment/xblock/ui_mixins/legacy/handlers_mixin.py
@@ -295,7 +295,7 @@ class LegacyHandlersMixin:
                 data['overall_feedback'],
                 self.config_data,
                 self.workflow_data,
-                self.self_data,
+                self.self_assessment_data,
             )
         except ReviewerMustHaveSubmittedException:
             return failure_response('You must submit a response before you can perform a self-assessment.')
@@ -376,7 +376,7 @@ class LegacyHandlersMixin:
                 data['overall_feedback'],
                 data.get('assess_type', 'regrade'),
                 self.config_data,
-                self.staff_data,
+                self.staff_assessment_data,
             )
         except (StaffAssessmentRequestError, StaffAssessmentInternalError):
             return failure_response('Your team assessment could not be submitted.')

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -120,6 +120,8 @@ class MfeMixin:
         step_data = None
 
         # Get the info for the current step
+        if step_name == "submission":
+            step_data = self.submission_data
         if step_name == "studentTraining":
             step_data = self.student_training_data
         elif step_name == "peer":

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -119,10 +119,17 @@ class MfeMixin:
         """
         step_data = None
 
-        # Get the info for the current step
+        # Users can always view a submission they've previously submitted
+        if step_name == "submission" and self.submission_data.has_submitted:
+            return True
+        # And whether they can get to grades, depends on the workflow being "done"
+        elif step_name == "done":
+            return self.workflow_data.is_done
+
+        # Otherwise, get the info for the current step to determine access
         if step_name == "submission":
             step_data = self.submission_data
-        if step_name == "studentTraining":
+        elif step_name == "studentTraining":
             step_data = self.student_training_data
         elif step_name == "peer":
             step_data = self.peer_assessment_data()
@@ -130,11 +137,10 @@ class MfeMixin:
             step_data = self.self_assessment_data
         elif step_name == "staff":
             step_data = self.staff_assessment_data
+        else:
+            raise OraApiException(400, error_codes.UNKNOWN_SUFFIX, error_context=f"Bad step name: {step_name}")
 
-        if not step_data:
-            raise OraApiException(400, error_codes.INVALID_STATE_TO_ASSESS)
-
-        # Return an error if the step is currently closed
+        # Return if the step is currently open
         return not step_data.problem_closed
 
     def _submission_draft_handler(self, data):

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -384,24 +384,8 @@ class MfeMixin:
         if suffix == handler_suffixes.ASSESSMENT_SUBMIT:
             step_name = data.get("step")
 
-            # Get the info for the current step
-            step_data = None
-            if step_name == "studentTraining":
-                step_data = self.student_training_data
-            elif step_name == "peer":
-                step_data = self.peer_assessment_data()
-            elif step_name == "self":
-                step_data = self.self_assessment_data
-            elif step_name == "staff":
-                step_data = self.staff_assessment_data
-
-            # Return an error if we are trying to assess from a bad step
-            if not step_data:
-                raise OraApiException(400, error_codes.INVALID_STATE_TO_ASSESS)
-
-            # Return an error if the step is currently closed
-            if step_data.problem_closed:
-                raise OraApiException(400, error_codes.INACCESSIBLE_STEP)
+            if not self._step_is_open(step_name):
+                raise OraApiException(400, error_codes.INACCESSIBLE_STEP, f"Inaccessible step: {step_name}")
 
             # Continue on to assessing
             return self._assessment_submit_handler(data)

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -354,7 +354,7 @@ class MfeMixin:
                     assessment_data['feedback'],
                     self.config_data,
                     self.workflow_data,
-                    self.self_data
+                    self.self_assessment_data
                 )
             elif requested_step == 'studentTraining':
                 corrections = training_assess(

--- a/openassessment/xblock/ui_mixins/mfe/mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/mixin.py
@@ -95,7 +95,7 @@ class MfeMixin:
             return PageDataSerializer(self, context=serializer_context).data
 
         # Raise error if step is closed
-        elif not self._step_is_open(requested_step):
+        elif not self.is_step_open(requested_step):
             raise OraApiException(400, error_codes.INACCESSIBLE_STEP, f"Inaccessible step: {requested_step}")
 
         # Check to see if user can access this workflow step
@@ -110,7 +110,7 @@ class MfeMixin:
         serializer_context["requested_step"] = requested_step
         return PageDataSerializer(self, context=serializer_context).data
 
-    def _step_is_open(self, step_name):
+    def is_step_open(self, step_name):
         """
         Determine whether or not the requested step is open
 
@@ -184,7 +184,7 @@ class MfeMixin:
             return self._submission_draft_handler(data)
         elif suffix == handler_suffixes.SUBMISSION_SUBMIT:
             # Return an error if the submission step is not open
-            if self.submission_data.problem_closed:
+            if not self.is_step_open("submission"):
                 raise OraApiException(400, error_codes.INACCESSIBLE_STEP)
             return self._submission_create_handler(data)
         else:
@@ -343,7 +343,7 @@ class MfeMixin:
         requested_step = serializer.data['step']
         try:
             # Block assessing a closed step
-            if not self._step_is_open(requested_step):
+            if not self.is_step_open(requested_step):
                 raise OraApiException(400, error_codes.INACCESSIBLE_STEP, f"Inaccessible step: {requested_step}")
 
             # Block assessing a cancelled submission

--- a/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
+++ b/openassessment/xblock/ui_mixins/mfe/page_context_serializer.py
@@ -208,7 +208,7 @@ class StepInfoSerializer(Serializer):
     submission = SubmissionStepInfoSerializer(source="submission_data")
     studentTraining = StudentTrainingStepInfoSerializer(source="student_training_data")
     peer = PeerStepInfoSerializer(source="peer_assessment_data")
-    _self = SelfStepInfoSerializer(source="self_data")
+    _self = SelfStepInfoSerializer(source="self_assessment_data")
 
     def get_fields(self):
         # Hack to name one of the output fields "self", a reserved word

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -685,9 +685,8 @@ class SubmissionCreateTest(MFEHandlersTestBase):
     @scenario("data/basic_scenario.xml")
     def test_blocks_submit_when_step_closed(self, xblock, mock_is_step_open):
         mock_is_step_open.return_value = False
-        with self._mock_create_submission() as mock_submit:
+        with self._mock_create_submission():
             resp = self.request_create_submission(xblock)
-
             assert_error_response(resp, 400, error_codes.INACCESSIBLE_STEP)
 
 

--- a/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
+++ b/openassessment/xblock/ui_mixins/mfe/test_mfe_mixin.py
@@ -681,6 +681,15 @@ class SubmissionCreateTest(MFEHandlersTestBase):
             assert resp.status_code == 200
             assert_called_once_with_helper(mock_submit, self.DEFAULT_SUBMIT_VALUE["submission"]["textResponses"], 3)
 
+    @patch("openassessment.xblock.ui_mixins.mfe.mixin.MfeMixin.is_step_open")
+    @scenario("data/basic_scenario.xml")
+    def test_blocks_submit_when_step_closed(self, xblock, mock_is_step_open):
+        mock_is_step_open.return_value = False
+        with self._mock_create_submission() as mock_submit:
+            resp = self.request_create_submission(xblock)
+
+            assert_error_response(resp, 400, error_codes.INACCESSIBLE_STEP)
+
 
 @ddt.ddt
 class FileUploadTest(MFEHandlersTestBase):
@@ -1012,3 +1021,17 @@ class AssessmentSubmitTest(MFEHandlersTestBase):
                 resp = self.request_assessment_submit(xblock, step='studentTraining')
 
         assert_error_response(resp, 400, error_codes.TRAINING_ANSWER_INCORRECT, corrections)
+
+    @patch("openassessment.xblock.ui_mixins.mfe.mixin.MfeMixin.is_step_open")
+    @ddt.data('self', 'studentTraining', 'peer')
+    @scenario("data/basic_scenario.xml")
+    def test_blocks_assess_when_step_closed(self, xblock, mfe_step, mock_is_step_open):
+        mock_is_step_open.return_value = False
+        with self.mock_assess_functions() as assess_mocks:
+            with self.mock_workflow_status(mfe_step):
+                resp = self.request_assessment_submit(xblock, step=mfe_step)
+
+        assert_error_response(resp, 400, error_codes.INACCESSIBLE_STEP, f"Inaccessible step: {mfe_step}")
+        assess_mocks.self.assert_not_called()
+        assess_mocks.training.assert_not_called()
+        assess_mocks.peer.assert_not_called()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.30",
+  "version": "6.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.29",
+      "version": "6.0.31",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@openedx/paragon": "^21.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.30",
+  "version": "6.0.31",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -** Fix an issue where we weren't validating step dates, allowing students to visit steps early / late.

JIRA: [AU-1680](https://2u-internal.atlassian.net/browse/AU-1680)

**What changed?**

- Adds "step is open" checks to any access of specific step data.
- Refactor for more consistent step data accessor names.
- Pairs with frontend fixes in https://github.com/openedx/frontend-app-ora/pull/179

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

Create ORAs with the following date configurations and verify they block improper access:
1. Submission not available yet (should show info and not show prompt)
2. Steps not available yet (should error and not allow access)
3. Submission / steps closed (should show error and disallow access)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
