### PR TITLE
[FC-0049] feat: Serialize tag data in OpenAssessmentBlocks

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.0.32'
+__version__ = '6.0.33'

--- a/openassessment/xblock/test/test_xml.py
+++ b/openassessment/xblock/test/test_xml.py
@@ -216,6 +216,40 @@ class TestSerializeContent(TestCase):
         xml_str = serialize_assessments_to_xml_str(self.oa_block)
         self.assertIn(data['assessments'][0]['name'], xml_str)
 
+    @ddt.file_data('data/serialize.json')
+    def test_serialize_with_tags(self, data):
+        self._configure_xblock(data)
+
+        # Create a mocked serialize tag data method that returns no data
+        def add_tags_to_node_no_tags(node):  # pylint: disable=unused-argument
+            return
+
+        # Manually add the mocked method to the OpenAssessment block instance
+        # This method will be added in the edx-platform repo through applying XBLOCK_MIXINS
+        self.oa_block.add_tags_to_node = add_tags_to_node_no_tags
+
+        xml = serialize_content(self.oa_block)
+
+        # Confirm that no tags appear in the xml
+        self.assertNotIn("tags-v1", xml)
+
+        # Create a mocked serialize tag data method that returns data
+        def add_tags_to_node_with_tags(node):
+            # return "lightcast-skills:Typing,Microsoft Office"
+            node.set('tags-v1', 'lightcast-skills:Typing,Microsoft Office')
+
+        # Manually add the mocked method to the OpenAssessment block instance
+        # This method will be added in the edx-platform repo through applying XBLOCK_MIXINS
+        self.oa_block.add_tags_to_node = add_tags_to_node_with_tags
+
+        xml = serialize_content(self.oa_block)
+
+        # Confirm that tags appear in the xml
+        self.assertIn("tags-v1=\"lightcast-skills:Typing,Microsoft Office\"", xml)
+
+        # Clear the mocked serialize tag data method
+        del self.oa_block.add_tags_to_node
+
     def test_mutated_criteria_dict(self):
         self._configure_xblock({})
 

--- a/openassessment/xblock/utils/xml.py
+++ b/openassessment/xblock/utils/xml.py
@@ -772,6 +772,11 @@ def serialize_content_to_xml(oa_block, root):
     if oa_block.show_rubric_during_response is not None:
         root.set('show_rubric_during_response', str(oa_block.show_rubric_during_response))
 
+    # Serialize and add tag data if any
+    if hasattr(oa_block, 'add_tags_to_node') and callable(oa_block.add_tags_to_node):  # pylint: disable=no-member
+        # This comes from TaggedBlockMixin
+        oa_block.add_tags_to_node(root)  # pylint: disable=no-member
+
 
 def serialize_content(oa_block):
     """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.31",
+  "version": "6.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edx-ora2",
-      "version": "6.0.31",
+      "version": "6.0.33",
       "dependencies": {
         "@edx/frontend-build": "8.0.6",
         "@openedx/paragon": "^21.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.0.32",
+  "version": "6.0.33",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
**TL;DR -**  This PR utilizes changes introduced in https://github.com/openedx/edx-platform/pull/34145/ to serialize and include tags data in OpenAssessmentBlocks

**What changed?**

- The new `serialize_tag_data` is called and the result (if any) is added to the OLX node

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

Follow the testing instruction in https://github.com/openedx/edx-platform/pull/34145/ and make sure to [setup ora2 locally](https://github.com/openedx/edx-ora2/blob/master/docs/developers_guide.rst#id2) on this branch, and include a few OpenAssessmentBlocks in the course and apply a few tags on it and then double check that `tags-v1` is included in the OLX (if tags are applied to the block)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
