### PR TITLE
feat: deserialize tag info from xml [FC-0049]

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.1.0'
+__version__ = '6.2.0'

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -18,7 +18,7 @@ from lazy import lazy
 from webob import Response
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchServiceError
-from xblock.fields import Boolean, Integer, List, Scope, String
+from xblock.fields import Boolean, Dict, Integer, List, Scope, String
 
 from openassessment.staffgrader.staff_grader_mixin import StaffGraderMixin
 from openassessment.workflow.errors import AssessmentWorkflowError
@@ -282,6 +282,9 @@ class OpenAssessmentBlock(
         scope=Scope.content,
         help="A title to display to a student (plain text)."
     )
+
+    xml_attributes = Dict(help="Map of unhandled xml attributes, used only for storage between import and export",
+                          default={}, scope=Scope.settings)
 
     white_listed_file_types = List(
         default=[],
@@ -934,6 +937,12 @@ class OpenAssessmentBlock(
         block.text_response_editor = config['text_response_editor']
         block.title = config['title']
         block.white_listed_file_types_string = config['white_listed_file_types']
+
+        # Deserialize and add tag data info to block if any
+        if hasattr(block, 'read_tags_from_node') and callable(block.read_tags_from_node):  # pylint: disable=no-member
+            # This comes from TaggedBlockMixin
+            block.read_tags_from_node(node)  # pylint: disable=no-member
+
         return block
 
     @property

--- a/openassessment/xblock/test/data/content_tags.xml
+++ b/openassessment/xblock/test/data/content_tags.xml
@@ -1,4 +1,4 @@
-<openassessment text_response="required" file_upload_response="" group_access="{&quot;381451918&quot;: [1179773159]}" prompts_type="text" v1-tags="test content types info">
+<openassessment text_response="required" file_upload_response="" group_access="{&quot;381451918&quot;: [1179773159]}" prompts_type="text" tags-v1="test content tags">
     <title>Open Assessment Test</title>
     <prompts>
         <prompt>

--- a/openassessment/xblock/test/data/content_tags.xml
+++ b/openassessment/xblock/test/data/content_tags.xml
@@ -1,0 +1,93 @@
+<openassessment text_response="required" file_upload_response="" group_access="{&quot;381451918&quot;: [1179773159]}" prompts_type="text" v1-tags="test content types info">
+    <title>Open Assessment Test</title>
+    <prompts>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat poverty? Please answer in a short essay of 200-300 words.</description>
+        </prompt>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat pollution?</description>
+        </prompt>
+    </prompts>
+    <rubric>
+        <criterion>
+            <name>Concise</name>
+            <prompt>How concise is it?</prompt>
+            <option points="0">
+                <name>Neal Stephenson (late)</name>
+                <explanation>Neal Stephenson explanation</explanation>
+            </option>
+            <option points="1">
+                <name>HP Lovecraft</name>
+                <explanation>HP Lovecraft explanation</explanation>
+            </option>
+            <option points="3">
+                <name>Robert Heinlein</name>
+                <explanation>Robert Heinlein explanation</explanation>
+            </option>
+            <option points="4">
+                <name>Neal Stephenson (early)</name>
+                <explanation>Neal Stephenson (early) explanation</explanation>
+            </option>
+            <option points="5">
+                <name>Earnest Hemingway</name>
+                <explanation>Earnest Hemingway</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Clear-headed</name>
+            <prompt>How clear is the thinking?</prompt>
+            <option points="0">
+                <name>Yogi Berra</name>
+                <explanation>Yogi Berra explanation</explanation>
+            </option>
+            <option points="1">
+                <name>Hunter S. Thompson</name>
+                <explanation>Hunter S. Thompson explanation</explanation>
+            </option>
+            <option points="2">
+                <name>Robert Heinlein</name>
+                <explanation>Robert Heinlein explanation</explanation>
+            </option>
+            <option points="3">
+                <name>Isaac Asimov</name>
+                <explanation>Isaac Asimov explanation</explanation>
+            </option>
+            <option points="10">
+                <name>Spock</name>
+                <explanation>Spock explanation</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>Lastly, how is its form? Punctuation, grammar, and spelling all count.</prompt>
+            <option points="0">
+                <name>lolcats</name>
+                <explanation>lolcats explanation</explanation>
+            </option>
+            <option points="1">
+                <name>Facebook</name>
+                <explanation>Facebook explanation</explanation>
+            </option>
+            <option points="2">
+                <name>Reddit</name>
+                <explanation>Reddit explanation</explanation>
+            </option>
+            <option points="3">
+                <name>metafilter</name>
+                <explanation>metafilter explanation</explanation>
+            </option>
+            <option points="4">
+                <name>Usenet, 1996</name>
+                <explanation>Usenet, 1996 explanation</explanation>
+            </option>
+            <option points="5">
+                <name>The Elements of Style</name>
+                <explanation>The Elements of Style explanation</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment" must_grade="5" must_be_graded_by="3" />
+        <assessment name="self-assessment" />
+    </assessments>
+</openassessment>

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -733,6 +733,11 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         # Given this ORA has rearranged our assessment steps
         self.assertTrue(xblock.mfe_views_supported)
 
+    @scenario('data/content_tags.xml')
+    def test_content_tags(self, xblock):
+        # Check if content tags are set properly
+        self.assertEqual(xblock.xml_attributes["v1-tags"], "test content tags")
+
 
 class TestDates(XBlockHandlerTestCase):
     """ Test Assessment Dates. """

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -8,6 +8,7 @@ import json
 from unittest import mock
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 from django.test.utils import override_settings
+from workbench.runtime import WorkbenchRuntime
 
 import ddt
 import pytz
@@ -22,6 +23,29 @@ from openassessment.xblock.openassesment_template_mixin import UI_MODELS
 from openassessment.xblock.apis.assessments.staff_assessment_api import StaffAssessmentAPI
 
 from .base import XBlockHandlerTestCase, scenario
+
+
+original_construct_xblock_from_class = WorkbenchRuntime.construct_xblock_from_class
+
+
+def _read_tags_from_node(self, node):
+    """
+    This method is originally defined in the XmlMixin in edx-platform.
+    """
+    if 'tags-v1' in node.attrib:
+        self.xml_attributes['tags-v1'] = str(node.attrib['tags-v1'])
+
+
+def _construct_xblock_from_class(*args, **kwargs):
+    """
+    Mock the original construct_xblock_from_class method to add the read_tags_from_node method and xml_attributes
+    property to the xblock.
+
+    In edx-platform, these members are part of the XmlMixin.
+    """
+    xblock = original_construct_xblock_from_class(*args, **kwargs)
+    xblock.read_tags_from_node = lambda node: _read_tags_from_node(xblock, node)
+    return xblock
 
 
 def assert_is_closed(
@@ -733,10 +757,11 @@ class TestOpenAssessment(XBlockHandlerTestCase):
         # Given this ORA has rearranged our assessment steps
         self.assertTrue(xblock.mfe_views_supported)
 
+    @patch.object(WorkbenchRuntime, 'construct_xblock_from_class', new=_construct_xblock_from_class)
     @scenario('data/content_tags.xml')
     def test_content_tags(self, xblock):
         # Check if content tags are set properly
-        self.assertEqual(xblock.xml_attributes["v1-tags"], "test content tags")
+        self.assertEqual(xblock.xml_attributes["tags-v1"], "test content tags")
 
 
 class TestDates(XBlockHandlerTestCase):

--- a/openassessment/xblock/test/test_openassessment.py
+++ b/openassessment/xblock/test/test_openassessment.py
@@ -32,8 +32,8 @@ def _read_tags_from_node(self, node):
     """
     This method is originally defined in the XmlMixin in edx-platform.
     """
-    if 'tags-v1' in node.attrib:
-        self.xml_attributes['tags-v1'] = str(node.attrib['tags-v1'])
+    assert 'tags-v1' in node.attrib
+    self.xml_attributes['tags-v1'] = str(node.attrib['tags-v1'])
 
 
 def _construct_xblock_from_class(*args, **kwargs):
@@ -1190,7 +1190,8 @@ class IsClosedDateConfigTypeTestCase(XBlockHandlerTestCase):
                     dt.datetime.fromisoformat(assessment.get('start')),
                     dt.datetime.fromisoformat(assessment.get('due'))
                 )
-        return None
+
+        assert False, f"Assessment {step} not found"  # pragma: no cover
 
     def setup_dates(self, xblock, course_dates=None, subsection_dates=None):
         """


### PR DESCRIPTION
## Description

This PR adds support to deserialize tag info from the block XML, adding it to the new `xml_attributes` property. This is used to allow pasting OpenAsssessments components with their applied tags.

## More Information
- Part of: https://github.com/openedx/modular-learning/issues/180

## Testing instructions
- Please ensure that the tests cover the expected behavior
- Follow the instructions at https://github.com/openedx/edx-platform/pull/34270 and check if you can copy/paste an Open Assessment with tags and ensure that the tags are copied correctly
