### PR TITLE
docs: ADR for lightweight extension points

### DIFF
--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -18,11 +18,12 @@ Decisions
 
 We'll enable external interactions with students' responses by using the `Hooks Extensions Framework`_. Using this approach, we'll implement extension points with minimal modifications in the edx-ora2 repository, making interventions with the students' response lifecycle possible. This is an interim solution for the problem stated above while the community develops a more sophisticated process that covers more use cases. 
 
-This approach includes implementing two extension points:
+This approach includes implementing two extension points, which definitions will live in `openedx-filters`_ and `openedx-events`_ accordingly:
 
-- For the first extension point we will use an `Open edX Filter`_ with the following definition:
+For the first extension point we will use an `Open edX Filter`_ with the following definition:
 
-.. code::
+
+..  code-block:: python
   
   class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
       """
@@ -44,7 +45,8 @@ This approach includes implementing two extension points:
 
 That will be triggered before `rendering the submission HTML section of the block for the legacy view`_:
 
-.. code::
+
+..  code-block:: python
 
     if path == "legacy/response/oa_response.html":
         try:
@@ -56,9 +58,10 @@ That will be triggered before `rendering the submission HTML section of the bloc
 
 This implementation will allow us to modify what's rendered to the student, via the view context and template, for cases when needed. For example, some third-party services need acknowledgment before receiving users' information.
 
-- The second extension point will be an Open edX Event. The event payload should contain enough information for later processing; in this case, we'll the following event definition:
+The second extension point will be an Open edX Event. The event payload should contain enough information for later processing; in this case, we'll the following event definition:
 
-.. code::
+
+..  code-block:: python
 
     attr.s(frozen=True)
     class ORASubmissionData:
@@ -90,7 +93,8 @@ This implementation will allow us to modify what's rendered to the student, via 
 
 The event will be sent `after a student submits a response to the assessment`_ so it has access to the student's submission key data:
 
-.. code::
+
+..  code-block:: python
 
     @staticmethod
     def send_ora_submission_created_event(submission: dict) -> None:
@@ -111,8 +115,7 @@ The event will be sent `after a student submits a response to the assessment`_ s
             )
         )
 
-     ...
-
+     # Sent after the submission
      self.send_ora_submission_created_event(submission)
 
 This event will allow us to act after a submission is made based on the data sent.
@@ -128,7 +131,8 @@ Extension developers commonly use those extension points in Open edX plugins to 
 
 Let's say you want to add an acknowledgment notice to your submission template so students know their information is being shared with third-party services when submitting a response. The extension developer could implement a `pipeline step`_ for the filter that changes the ``oa_response.html`` template for an ``oa_response_ack_modified.html`` template with its context:
 
-.. code::
+
+..  code-block:: python
 
     from openedx_filters import PipelineStep
     
@@ -157,7 +161,8 @@ Let's say you want to add an acknowledgment notice to your submission template s
 
 See `how to implement pipeline steps`_ for more information. Now, by listening to the `Open edX Event`_, the developer could act on the submission-created notification. Since the event payload has enough information to get the student's submissions, including files, the event receiver can obtain the submission to send it to another service for analysis:
 
-.. code::
+
+..  code-block:: python
 
     from some_plugin.tasks import ora_submission_created_processing_task
 
@@ -192,4 +197,6 @@ customization and addition to the workflow step, it was concluded that the more 
 .. _how to implement pipeline steps: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/using-filters.html#implement-pipeline-steps
 .. _how to listen for Open edX Events: https://docs.openedx.org/projects/openedx-events/en/latest/how-tos/using-events.html#receiving-events
 .. _after a student submits a response to the assessment: https://github.com/openedx/edx-ora2/blob/master/openassessment/xblock/ui_mixins/legacy/handlers_mixin.py#L67
-.. _`platform roadmap GH ticket`: https://github.com/openedx/platform-roadmap/issues/253
+.. _platform roadmap GH ticket: https://github.com/openedx/platform-roadmap/issues/253
+.. _openedx-events: https://github.com/openedx/openedx-events
+.. _openedx-filters: https://github.com/openedx/openedx-filters

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -9,16 +9,16 @@ Status
 Context
 *******
 
-Open-ended questions are commonly used in education for assessment purposes, but their flexible nature can facilitate cheating. Therefore, instructors need a way of assessing when cheating happens when reviewing responses. One widely-used solution to this problem in the academic field is online plagiarism tools. These tools receive the students' responses, analyze them, and provide reports that assist instructors in scoring.
+Open-ended questions are commonly used in education for assessment purposes, but their flexible nature can facilitate cheating. Therefore, instructors need a way of assessing when cheating happens when reviewing responses. One widely-used solution to this problem in the academic field is the use online plagiarism tools by instructors. These tools receive the students' responses, analyze them, and provide reports that assist instructors in scoring.
 
-No standard exists for ORA to facilitate integration with tools that process students' answers for plagiarism or other useful reports. Therefore, ORA must allow external interactions with students' responses so they can be sent for analysis.
+No standard exists for ORA to facilitate integration with tools that process students' answers for plagiarism or other useful reports for the course staff. Therefore, ORA must allow external interactions with students' responses so they can be sent for analysis.
 
 Decision
 ********
 
 We'll enable external interactions with students' responses by using the `Hooks Extensions Framework`_. Using this approach, we'll implement extension points with minimal modifications in the edx-ora2 repository, making interventions with the students' response lifecycle possible. This is an interim solution for the problem stated above while the community develops a more sophisticated process that covers more use cases. This approach includes implementing two extension points:
 
-- The first extension point will implemented before rendering the submission HTML section of the block for the legacy view. We'll use an `Open edX Filter`_ with the following definition:
+- The first extension point will implemented before `rendering the submission HTML section of the block for the legacy view`_. We'll use an `Open edX Filter`_ with the following definition:
 
 .. code::
   
@@ -40,9 +40,9 @@ We'll enable external interactions with students' responses by using the `Hooks 
           data = super().run_pipeline(context=context, template_name=template_name, )
           return data.get("context"), data.get("template_name")
 
-This implementation will allow us to modify what's rendered to the student for cases when needed. For example, some third-party services need acknowledgment before receiving users' information.
+This implementation will allow us to modify what's rendered to the student, via the view context and template, for cases when needed. For example, some third-party services need acknowledgment before receiving users' information.
 
-- The second extension point will be an Open edX Event sent after a student submits a response to the assessment. The event payload should contain enough information for later processing; in this case, we'll the following event definition:
+- The second extension point will be an Open edX Event sent `after a student submits a response to the assessment`_. The event payload should contain enough information for later processing; in this case, we'll the following event definition:
 
 .. code::
 
@@ -83,7 +83,7 @@ Extension developers commonly use those extension points in Open edX plugins to 
 - Change the template that is rendered to the student
 - Send students' submission data to another service
 
-Let's say you want to add an acknowledgment notice to your submission template so students know their information is being shared with third-party services when submitting a response. The extension developer could implement a pipeline step for the filter that changes the ``oa_response.html`` template for an ``oa_response_ack_modified.html`` template with its context:
+Let's say you want to add an acknowledgment notice to your submission template so students know their information is being shared with third-party services when submitting a response. The extension developer could implement a `pipeline step`_ for the filter that changes the ``oa_response.html`` template for an ``oa_response_ack_modified.html`` template with its context:
 
 .. code::
 
@@ -109,10 +109,10 @@ Let's say you want to add an acknowledgment notice to your submission template s
             """
             return {
                 "context": context,
-                "template_name": "some_plugin/oa_response_ack_modified.html",
+                "template_name": "some_plugin/oa_response_with_acknowledgement.html",
             }
 
-By listening to the Open edX Event, the developer could act on the submission-created notification. Since the event payload has enough information to get the student's submissions, including files, the event receiver can obtain the submission to send it to another service for analysis:
+See `how to implement pipeline steps`_ for more information. Now, by listening to the `Open edX Event`_, the developer could act on the submission-created notification. Since the event payload has enough information to get the student's submissions, including files, the event receiver can obtain the submission to send it to another service for analysis:
 
 .. code::
 
@@ -131,7 +131,7 @@ By listening to the Open edX Event, the developer could act on the submission-cr
             submission.file_downloads,
         )
 
-Extension developers could interact with an essential part of the student's assessment lifecycle with these changes. But when none of these extension points are configured for use, then ORA assessments will behave as usual.
+See `how to listen for Open edX Events`_ for more information. Extension developers could interact with an essential part of the student's assessment lifecycle with these changes. But when none of these extension points are configured for use, then ORA assessments will behave as usual.
 
 Rejected Alternatives
 *********************
@@ -140,4 +140,11 @@ As suggested in the `platform roadmap GH ticket`_ for this feature, the team res
 customization and addition to the workflow step, it was concluded that the more straightforward solution was implementing a lightweight extension mechanism. 
 
 .. _Hooks Extensions Framework: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0050-hooks-extension-framework.html
+.. _rendering the submission HTML section of the block for the legacy view: https://github.com/openedx/edx-ora2/blob/master/openassessment/xblock/ui_mixins/legacy/views/submission.py#L19
+.. _Open edX Filter: https://docs.openedx.org/projects/openedx-filters/en/latest/
+.. _Open edX Event: https://docs.openedx.org/projects/openedx-filters/en/latest/
+.. _pipeline step: https://docs.openedx.org/projects/openedx-filters/en/latest/concepts/glossary.html#pipeline-steps
+.. _how to implement pipeline steps: https://docs.openedx.org/projects/openedx-filters/en/latest/how-tos/using-filters.html#implement-pipeline-steps
+.. _how to listen for Open edX Events: https://docs.openedx.org/projects/openedx-events/en/latest/how-tos/using-events.html#receiving-events
+.. _after a student submits a response to the assessment: https://github.com/openedx/edx-ora2/blob/master/openassessment/xblock/ui_mixins/legacy/handlers_mixin.py#L67
 .. _`platform roadmap GH ticket`: https://github.com/openedx/platform-roadmap/issues/253

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -1,64 +1,99 @@
 Lightweight extension points
 ############################
 
-.. The title should be a short noun phrase. For example, "1. Django IDA" or "9. LDAP for Multitenant Integration"; filename should be lowercase with punctuation removed and spaces replaced by dash
-
 Status
-
 ******
 
 **Draft** *2024-02-27*
 
 Context
-
 *******
 
-.. This section describes the forces at play, including technological, political, social, and project local. These forces are probably in tension, and should be called out as such. The language in this section is value-neutral. It is simply describing facts.
+Open-ended questions are commonly used in education for assessment purposes, but their flexible nature can facilitate cheating. Therefore, instructors need a way of assessing when cheating happens when reviewing responses. One widely-used solution to this problem in the academic field is online plagiarism tools. These tools receive the students' responses, analyze them, and provide reports that assist instructors in scoring.
 
-
-
-Here we can add:
-
-What instructors need and why (external response processing)
-
-What's currently available in ORA to do so (instructor → configurations and what ora offers out of the box / developer POV → extension methods)
+No standard exists for ORA to facilitate integration with tools that process students' answers for plagiarism report or other useful tasks. Therefore, ORA must allow external interactions with students' responses so they can be sent for analysis.
 
 Decision
-
 ********
 
-.. This section describes our response to these forces. It is stated in full sentences, with active voice. "We will …"
+We'll enable external interactions with students' responses by using the `Hooks Extensions Framework`_. Using this approach, we'll implement extension points with minimal modifications in the edx-ora2 repository, making interventions with the students' response lifecycle possible. This is an interim solution for the problem stated above while the community develops a more sophisticated process that covers more use cases. This approach includes implementing two extension points:
 
-Here we can add:
+- The first extension point will implemented before rendering the submission HTML section of the block for the legacy view. We'll use an Open edX Filter with the following definition:
 
-Open extension points for plugin processing / interaction, no need for new step? how to argue that?
+.. code::
+  
+  class ORASubmissionViewRenderStarted(OpenEdxPublicFilter):
+      """
+      Custom class used to create ORA submission view filters and its custom methods.
+      """
+  
+      filter_type = "org.openedx.learning.ora.submission_view.render.started.v1"
+  
+      @classmethod
+      def run_filter(cls, context: dict, template_name: str):
+          """
+          Execute a filter with the signature specified.
+          Arguments:
+              context (dict): context dictionary for submission view template.
+              template_name (str): template name to be rendered by the student's dashboard.
+          """
+          data = super().run_pipeline(context=context, template_name=template_name, )
+          return data.get("context"), data.get("template_name")
 
-Or say: 1st step for new interactions outside ORA??
+This implementation will allow us to modify what's rendered to the student for cases when needed. For example, some third-party services need acknowledgment before receiving users' information.
+
+- The second extension point will be an Open edX Event sent after a student submits a response to the assessment. The event payload should contain enough information for later processing; in this case, we'll the following event definition:
+
+.. code::
+
+    attr.s(frozen=True)
+    class ORASubmissionData:
+        """
+        Attributes defined to represent event when a user submits an ORA assignment.
+
+        Arguments:
+            id (str): identifier of the ORA submission.
+            file_downloads (List[dict]): list of related files in the ORA submission. Each dict
+                contains the following keys:
+                    * download_url (str): URL to download the file.
+                    * description (str): Description of the file.
+                    * name (str): Name of the file.
+                    * size (int): Size of the file.
+        """
+        id = attr.ib(type=str)
+        file_downloads = attr.ib(type=List[dict], factory=list)
+
+    # .. event_type: org.openedx.learning.ora.submission.created.v1
+    # .. event_name: ORA_SUBMISSION_CREATED
+    # .. event_description: Emitted when a new ORA submission is created
+    # .. event_data: ORASubmissionData
+    ORA_SUBMISSION_CREATED = OpenEdxPublicSignal(
+        event_type="org.openedx.learning.ora.submission.created.v1",
+        data={
+            "submission": ORASubmissionData,
+        },
+    )
 
 Consequences
-
 ************
 
-.. This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future.
+Extension developers commonly use those kind of extension points in Open edX plugins to extend an existing application, like the LMS. So, when installing edx-ora2 in the LMS with these changes alongside a plugin configured to use them, ORA extension developers will be able to:
 
-Or say: 1st step for new interactions outside ORA??
+- Modify the context passed to ``legacy/response/oa_response.html`` 
+- Change the template that is rendered to the student
+- Send students' submission data to another service
 
-Send data to services
+Let's say you want to add an acknowledgment notice to your submission template so students know their information is being shared with third-party services when submitting a response. The extension developer could implement a pipeline step for the filter that changes the ``oa_response.html`` template for a ``oa_response_ack_modified.html`` template with its context.
 
-Modify student steps? what are they call?
+By listening to the Open edX Event, the developer could act on the submission-created notification. Since the event payload has enough information to get the student's submissions, including files, the event receiver can obtain the submission to send it to another service for analysis.
+
+With these changes, extension developers could interact with an essential part of the students' assessment lifecycle. But when none of these extension points are configured for use, then ORA assessments will behave as usual.
 
 Rejected Alternatives
-
 *********************
 
 .. This section lists alternate options considered, described briefly, with pros and cons.
 
 FOR THE MOMENT: a new step
 
-References
-
-**********
-
-.. (Optional) List any additional references here that would be useful to the future reader. See `Documenting Architecture Decisions`_ for further input.
-
-.. _Documenting Architecture Decisions: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
+.. _Hooks Extensions Framework: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0050-hooks-extension-framework.html

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -16,7 +16,7 @@ As the code is open, it is always possible to modify it. Still, it might result 
 Decisions
 *********
 
-As the first step towards making the instructor's involvement in the learners' lifecycle more flexible, we will introduce two extension points in the ORA codebase. These extension points will be built on top of the `Hooks Extensions Framework`_. The definitions for these extension points will reside in `openedx-filters`_ and `openedx-events`_. These definitions will be imported into the edx-ora2 repository and triggered in two places during the learners' lifecycle, resulting in minimal modifications to the ORA implementation.
+As the first step towards making implementing new use cases during the ORA user's lifecycle more flexible, we will introduce two extension points in the ORA codebase. These extension points will be built on top of the `Hooks Extensions Framework`_. The definitions for these extension points will reside in `openedx-filters`_ and `openedx-events`_. These definitions will be imported into the edx-ora2 repository and triggered in two places during the learners' lifecycle, resulting in minimal modifications to the ORA implementation.
 
 The first extension point we will implement is an `Open edX Filter`_ that will be executed before `rendering the submission HTML section of the block for the legacy view`_, with input arguments ``context`` and ``template path``. This implementation will allow us to modify what's rendered to the student, via the view ``context`` and ``template``, for cases when needed. 
 

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -18,7 +18,7 @@ Decision
 
 We'll enable external interactions with students' responses by using the `Hooks Extensions Framework`_. Using this approach, we'll implement extension points with minimal modifications in the edx-ora2 repository, making interventions with the students' response lifecycle possible. This is an interim solution for the problem stated above while the community develops a more sophisticated process that covers more use cases. This approach includes implementing two extension points:
 
-- The first extension point will implemented before rendering the submission HTML section of the block for the legacy view. We'll use an Open edX Filter with the following definition:
+- The first extension point will implemented before rendering the submission HTML section of the block for the legacy view. We'll use an `Open edX Filter`_ with the following definition:
 
 .. code::
   
@@ -136,11 +136,8 @@ Extension developers could interact with an essential part of the student's asse
 Rejected Alternatives
 *********************
 
-As suggested in the `platform roadmap ticket`_ for this feature, the team researched the feasibility of adding a new pluggable assessment step. However, although this was considered the best option since ORA design entertained extension via
-customization and addition to the workflow step, 
-
-References
-**********
+As suggested in the `platform roadmap GH ticket`_ for this feature, the team researched the feasibility of adding a new pluggable assessment step. Although this was considered the best option since ORA design entertained extension via
+customization and addition to the workflow step, it was concluded that the more straightforward solution was implementing a lightweight extension mechanism. 
 
 .. _Hooks Extensions Framework: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0050-hooks-extension-framework.html
-.. _`platform roadmap ticket`: https://github.com/openedx/platform-roadmap/issues/253
+.. _`platform roadmap GH ticket`: https://github.com/openedx/platform-roadmap/issues/253

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -1,0 +1,64 @@
+Lightweight extension points
+############################
+
+.. The title should be a short noun phrase. For example, "1. Django IDA" or "9. LDAP for Multitenant Integration"; filename should be lowercase with punctuation removed and spaces replaced by dash
+
+Status
+
+******
+
+**Draft** *2024-02-27*
+
+Context
+
+*******
+
+.. This section describes the forces at play, including technological, political, social, and project local. These forces are probably in tension, and should be called out as such. The language in this section is value-neutral. It is simply describing facts.
+
+
+
+Here we can add:
+
+What instructors need and why (external response processing)
+
+What's currently available in ORA to do so (instructor → configurations and what ora offers out of the box / developer POV → extension methods)
+
+Decision
+
+********
+
+.. This section describes our response to these forces. It is stated in full sentences, with active voice. "We will …"
+
+Here we can add:
+
+Open extension points for plugin processing / interaction, no need for new step? how to argue that?
+
+Or say: 1st step for new interactions outside ORA??
+
+Consequences
+
+************
+
+.. This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future.
+
+Or say: 1st step for new interactions outside ORA??
+
+Send data to services
+
+Modify student steps? what are they call?
+
+Rejected Alternatives
+
+*********************
+
+.. This section lists alternate options considered, described briefly, with pros and cons.
+
+FOR THE MOMENT: a new step
+
+References
+
+**********
+
+.. (Optional) List any additional references here that would be useful to the future reader. See `Documenting Architecture Decisions`_ for further input.
+
+.. _Documenting Architecture Decisions: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -31,7 +31,7 @@ For instance, if a developer wants to add an acknowledgment notice to the submis
 
 These changes allow extension developers to interact with a crucial part of the student's assessment lifecycle. However, when none of these extension points are configured, ORA assessments will behave as usual. This first step sets a precedent for ORA developers to implement more extension points during the ORA users' lifecycle, enabling additional use cases to be built on top of them.
 
-The extension points proposed in this PR are intended to facilitate the integration with tools for students' response analysis like Turnitin. For more information on this use case, please refer to the `Platform Plugin Turnitin`_ documentation.
+The extension points proposed in this PR are intended to facilitate the integration with tools for students' response analysis like Turnitin.These two extensions are designed to share information, not to give feedback to the user; other hooks and mechanisms might be implemented to do so. For more information on this use case, please refer to the `Platform Plugin Turnitin`_ documentation.
 
 Rejected Alternatives
 *********************

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -11,7 +11,7 @@ Context
 
 Open-ended questions are commonly used in education for assessment purposes, but their flexible nature can facilitate cheating. Therefore, instructors need a way of assessing when cheating happens when reviewing responses. One widely-used solution to this problem in the academic field is online plagiarism tools. These tools receive the students' responses, analyze them, and provide reports that assist instructors in scoring.
 
-No standard exists for ORA to facilitate integration with tools that process students' answers for plagiarism report or other useful tasks. Therefore, ORA must allow external interactions with students' responses so they can be sent for analysis.
+No standard exists for ORA to facilitate integration with tools that process students' answers for plagiarism or other useful reports. Therefore, ORA must allow external interactions with students' responses so they can be sent for analysis.
 
 Decision
 ********
@@ -77,23 +77,70 @@ This implementation will allow us to modify what's rendered to the student for c
 Consequences
 ************
 
-Extension developers commonly use those kind of extension points in Open edX plugins to extend an existing application, like the LMS. So, when installing edx-ora2 in the LMS with these changes alongside a plugin configured to use them, ORA extension developers will be able to:
+Extension developers commonly use those extension points in Open edX plugins to extend an existing application, like the LMS. So, when installing edx-ora2 in the LMS with these changes alongside a plugin configured to use them, ORA extension developers will be able to:
 
 - Modify the context passed to ``legacy/response/oa_response.html`` 
 - Change the template that is rendered to the student
 - Send students' submission data to another service
 
-Let's say you want to add an acknowledgment notice to your submission template so students know their information is being shared with third-party services when submitting a response. The extension developer could implement a pipeline step for the filter that changes the ``oa_response.html`` template for a ``oa_response_ack_modified.html`` template with its context.
+Let's say you want to add an acknowledgment notice to your submission template so students know their information is being shared with third-party services when submitting a response. The extension developer could implement a pipeline step for the filter that changes the ``oa_response.html`` template for an ``oa_response_ack_modified.html`` template with its context:
 
-By listening to the Open edX Event, the developer could act on the submission-created notification. Since the event payload has enough information to get the student's submissions, including files, the event receiver can obtain the submission to send it to another service for analysis.
+.. code::
 
-With these changes, extension developers could interact with an essential part of the students' assessment lifecycle. But when none of these extension points are configured for use, then ORA assessments will behave as usual.
+    from openedx_filters import PipelineStep
+    
+    
+    class ORASubmissionViewTurnitinWarning(PipelineStep):
+        """Add warning message about Turnitin to the ORA submission view."""
+    
+        def run_filter(  # pylint: disable=unused-argument, disable=arguments-differ
+            self, context: dict, template_name: str
+        ) -> dict:
+            """
+            Execute filter that loads the submission template with a warning message that
+            notifies the user that the submission will be sent to Turnitin.
+    
+            Args:
+                context (dict): The context dictionary.
+                template_name (str): ORA template name.
+    
+            Returns:
+                dict: The context dictionary and the template name.
+            """
+            return {
+                "context": context,
+                "template_name": "some_plugin/oa_response_ack_modified.html",
+            }
+
+By listening to the Open edX Event, the developer could act on the submission-created notification. Since the event payload has enough information to get the student's submissions, including files, the event receiver can obtain the submission to send it to another service for analysis:
+
+.. code::
+
+    from some_plugin.tasks import ora_submission_created_processing_task
+
+    @receiver(ORA_SUBMISSION_CREATED)
+    def ora_submission_created(submission, **kwargs):
+        """
+        Handle the ORA_SUBMISSION_CREATED event.
+    
+        Args:
+            submission (ORASubmissionData): The ORA submission data.
+        """
+        ora_submission_created_processing_task.delay(
+            submission.id,
+            submission.file_downloads,
+        )
+
+Extension developers could interact with an essential part of the student's assessment lifecycle with these changes. But when none of these extension points are configured for use, then ORA assessments will behave as usual.
 
 Rejected Alternatives
 *********************
 
-.. This section lists alternate options considered, described briefly, with pros and cons.
+As suggested in the `platform roadmap ticket`_ for this feature, the team researched the feasibility of adding a new pluggable assessment step. However, although this was considered the best option since ORA design entertained extension via
+customization and addition to the workflow step, 
 
-FOR THE MOMENT: a new step
+References
+**********
 
 .. _Hooks Extensions Framework: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0050-hooks-extension-framework.html
+.. _`platform roadmap ticket`: https://github.com/openedx/platform-roadmap/issues/253

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -9,19 +9,16 @@ Status
 Context
 *******
 
-Open-ended questions are commonly used in education for assessment purposes, but their flexible nature can facilitate cheating. Therefore, instructors need a way of assessing when cheating happens when reviewing responses. One widely-used solution to this problem in the academic field is the use online plagiarism tools by instructors. These tools receive the students' responses, analyze them, and provide reports that assist instructors in scoring.
+Open Responses are commonly used in education for assessment purposes and the flexibility of ORA has made it a key feature of the Open edX platform. However, as developers, it is tough to accommodate the needs of educators and other stakeholders in the teaching process when they want to enhance the learner's experience with other tools such as plagiarism detection, AI grading, coding graders, and others.
 
-No standard exists for ORA to facilitate integration with tools that process students' answers for plagiarism or other useful reports for the course staff. Therefore, ORA must allow external interactions with students' responses so they can be sent for analysis.
+As the code is open, it is always possible to modify it. Still, it might result in a technical maintenance debt, which usually prevents educators from experimenting or installations from upgrading to newer versions once the changes to ORA become important in the teaching process.
 
 Decisions
 *********
 
-We'll enable external interactions with students' responses by using the `Hooks Extensions Framework`_. Using this approach, we'll implement extension points with minimal modifications in the edx-ora2 repository, making interventions with the students' response lifecycle possible. This is an interim solution for the problem stated above while the community develops a more sophisticated process that covers more use cases. 
-
-This approach includes implementing two extension points, which definitions will live in `openedx-filters`_ and `openedx-events`_ accordingly:
+As the first step towards making the instructor's involvement in the learners' lifecycle more flexible, we will introduce two extension points in ORA. These extension points will be built on top of the `Hooks Extensions Framework`_. The definitions for these extension points will reside in `openedx-filters`_ and `openedx-events`_. These definitions will be imported into the edx-ora2 repository and will be triggered when necessary, with minimal modifications to the ORA implementation.
 
 For the first extension point we will use an `Open edX Filter`_ with the following definition:
-
 
 ..  code-block:: python
   

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -31,12 +31,12 @@ For instance, if a developer wants to add an acknowledgment notice to the submis
 
 These changes allow extension developers to interact with a crucial part of the student's assessment lifecycle. However, when none of these extension points are configured, ORA assessments will behave as usual. This first step sets a precedent for ORA developers to implement more extension points during the ORA users' lifecycle, enabling additional use cases to be built on top of them.
 
+The extension points proposed in this PR are intended to facilitate the integration with tools for students' response analysis like Turnitin. For more information on this use case, please refer to the `Platform Plugin Turnitin`_ documentation.
+
 Rejected Alternatives
 *********************
 
-Given that there is currently no other option for extending ORA without a fork, we are not rejecting any other alternative. It could be argued that we are rejecting the construction of a more extensive (or more comprehensive) framework for extension, but it's more like this is the first step towards a larger framework. If we were to propose a project to extend ORA with a mechanism for dependency injection, we would still propose it to be built on top of the hooks framework.
-
-At this ADR, we are only committing to the first few hooks because we understand very well the effort it requires. However, there is no technical limit for this proposal to grow into more hooks and eventually support a broad array of extension use cases.
+As suggested in the `platform roadmap GH ticket`_ for this feature, the team who wrote this ADR researched the feasibility of adding a new `External Tool Step`. Although this was considered the best option since ORA design entertained extension via customization and addition of workflow steps, it was rejected due to time constraints. Therefore, in this ADR, we only commit to implementing a lightweight extension mechanism because we understand the required effort. However, there is no technical limit on this proposal's growth into more support of a broad array of extension use cases.
 
 .. _Hooks Extensions Framework: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0050-hooks-extension-framework.html
 .. _rendering the submission HTML section of the block for the legacy view: https://github.com/openedx/edx-ora2/blob/master/openassessment/xblock/ui_mixins/legacy/views/submission.py#L19
@@ -49,3 +49,4 @@ At this ADR, we are only committing to the first few hooks because we understand
 .. _platform roadmap GH ticket: https://github.com/openedx/platform-roadmap/issues/253
 .. _openedx-events: https://github.com/openedx/openedx-events
 .. _openedx-filters: https://github.com/openedx/openedx-filters
+.. _Platform Plugin Turnitin: https://github.com/eduNEXT/platform-plugin-turnitin

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -4,7 +4,7 @@ Lightweight extension points
 Status
 ******
 
-**Draft** *2024-02-27*
+**Accepted** *2024-04-04*
 
 Context
 *******

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -20,7 +20,7 @@ As the first step towards making implementing new use cases during the ORA user'
 
 The first extension point we will implement is an `Open edX Filter`_ that will be executed before `rendering the submission HTML section of the block for the legacy view`_, with input arguments ``context`` and ``template path``. This implementation will allow us to modify what's rendered to the student, via the view ``context`` and ``template``, for cases when needed. 
 
-The second extension point to be implemented is an `Open edX Event`_. It will be sent `after a student submits a response to the assessment`_ with the student's submission key data, like the ORA submission ID and files uploaded in the submission, as the event's payload. This event will allow us to take action after a submission is made based on the data sent.
+The second extension point to be implemented is an `Open edX Event`_. It will be sent `after a student submits a response to the assessment`_ with the student's submission key data, like the ORA submission ID and files uploaded in the submission, as the event's payload. This event (that works like a notification) will allow us to take action after a submission is made based on the data sent.
 
 Consequences
 ************

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -25,23 +25,18 @@ The second extension point to be implemented is an `Open edX Event`_. It will be
 Consequences
 ************
 
-Extension developers commonly use those extension points in Open edX plugins to extend the functionality of an existing application, like the LMS. So, when installing edx-ora2 in the LMS with these changes alongside a plugin configured to use them, ORA extension developers will be able to:
+Extension developers often use those extension points in Open edX plugins to enhance the functionality of an existing application. When installing edx-ora2, developers can implement more use cases out-of-the-box by configuring it with plugins that use these extension points. These use cases include modify the context passed to ``legacy/response/oa_response.html`` , changing the template that is rendered to the student, and sending students' submission data to another service.
 
-- Modify the context passed to ``legacy/response/oa_response.html`` 
-- Change the template that is rendered to the student
-- Send students' submission data to another service
+For instance, if a developer wants to add an acknowledgment notice to the submission template, they can implement a `pipeline step`_ for the filter that modifies the ``oa_response.html`` template for an ``oa_response_ack_modified.html`` template with its custom context. See `how to implement pipeline steps`_ for more information. To act on the submission-created notification, the developer can listen to the Open edX event since the event payload has enough information to get the student's submissions, including files, enabling the event receiver to obtain and send the submission to another service for analysis. See `how to listen for Open edX Events`_ for more information. 
 
-Let's say you want to add an acknowledgment notice to your submission template so students know their information is being shared with third-party services when submitting a response. The extension developer could implement a `pipeline step`_ for the filter that changes the ``oa_response.html`` template for an ``oa_response_ack_modified.html`` template with its custom context.
-
-See `how to implement pipeline steps`_ for more information. Now, the developer could act on the submission-created notification by listening to the `Open edX Event`_. Since the event payload has enough information to get the student's submissions, including files, the event receiver can obtain the submission to send it to another service for analysis. See `how to listen for Open edX Events`_ for more information. 
-
-Extension developers could interact with an essential part of the student's assessment lifecycle with these changes. But when none of these extension points are configured for use, then ORA assessments will behave as usual.
+These changes allow extension developers to interact with a crucial part of the student's assessment lifecycle. However, when none of these extension points are configured, ORA assessments will behave as usual. This first step sets a precedent for ORA developers to implement more extension points during the ORA users' lifecycle, enabling additional use cases to be built on top of them.
 
 Rejected Alternatives
 *********************
 
-As suggested in the `platform roadmap GH ticket`_ for this feature, the team researched the feasibility of adding a new pluggable assessment step. Although this was considered the best option since ORA design entertained extension via
-customization and addition to the workflow step, it was concluded that the more straightforward solution was implementing a lightweight extension mechanism. 
+Given that there is currently no other option for extending ORA without a fork, we are not rejecting any other alternative. It could be argued that we are rejecting the construction of a more extensive (or more comprehensive) framework for extension, but it's more like this is the first step towards a larger framework. If we were to propose a project to extend ORA with a mechanism for dependency injection, we would still propose it to be built on top of the hooks framework.
+
+At this ADR, we are only committing to the first few hooks because we understand very well the effort it requires. However, there is no technical limit for this proposal to grow into more hooks and eventually support a broad array of extension use cases.
 
 .. _Hooks Extensions Framework: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0050-hooks-extension-framework.html
 .. _rendering the submission HTML section of the block for the legacy view: https://github.com/openedx/edx-ora2/blob/master/openassessment/xblock/ui_mixins/legacy/views/submission.py#L19

--- a/docs/decisions/0003-lightweight-extension-points.rst
+++ b/docs/decisions/0003-lightweight-extension-points.rst
@@ -13,10 +13,12 @@ Open-ended questions are commonly used in education for assessment purposes, but
 
 No standard exists for ORA to facilitate integration with tools that process students' answers for plagiarism or other useful reports for the course staff. Therefore, ORA must allow external interactions with students' responses so they can be sent for analysis.
 
-Decision
-********
+Decisions
+*********
 
-We'll enable external interactions with students' responses by using the `Hooks Extensions Framework`_. Using this approach, we'll implement extension points with minimal modifications in the edx-ora2 repository, making interventions with the students' response lifecycle possible. This is an interim solution for the problem stated above while the community develops a more sophisticated process that covers more use cases. This approach includes implementing two extension points:
+We'll enable external interactions with students' responses by using the `Hooks Extensions Framework`_. Using this approach, we'll implement extension points with minimal modifications in the edx-ora2 repository, making interventions with the students' response lifecycle possible. This is an interim solution for the problem stated above while the community develops a more sophisticated process that covers more use cases. 
+
+This approach includes implementing two extension points:
 
 - For the first extension point we will use an `Open edX Filter`_ with the following definition:
 
@@ -40,7 +42,7 @@ We'll enable external interactions with students' responses by using the `Hooks 
           data = super().run_pipeline(context=context, template_name=template_name, )
           return data.get("context"), data.get("template_name")
 
-Triggered implemented before `rendering the submission HTML section of the block for the legacy view`_:
+That will be triggered before `rendering the submission HTML section of the block for the legacy view`_:
 
 .. code::
 
@@ -113,6 +115,7 @@ The event will be sent `after a student submits a response to the assessment`_ s
 
      self.send_ora_submission_created_event(submission)
 
+This event will allow us to act after a submission is made based on the data sent.
 
 Consequences
 ************
@@ -130,15 +133,15 @@ Let's say you want to add an acknowledgment notice to your submission template s
     from openedx_filters import PipelineStep
     
     
-    class ORASubmissionViewTurnitinWarning(PipelineStep):
-        """Add warning message about Turnitin to the ORA submission view."""
+    class ORASubmissionViewAcknowledgeWarning(PipelineStep):
+        """Add warning message about sharing users' information to the ORA submission view."""
     
         def run_filter(  # pylint: disable=unused-argument, disable=arguments-differ
             self, context: dict, template_name: str
         ) -> dict:
             """
             Execute filter that loads the submission template with a warning message that
-            notifies the user that the submission will be sent to Turnitin.
+            notifies the user that the submission will be sent to a 3rd party service.
     
             Args:
                 context (dict): The context dictionary.
@@ -171,7 +174,9 @@ See `how to implement pipeline steps`_ for more information. Now, by listening t
             submission.file_downloads,
         )
 
-See `how to listen for Open edX Events`_ for more information. Extension developers could interact with an essential part of the student's assessment lifecycle with these changes. But when none of these extension points are configured for use, then ORA assessments will behave as usual.
+See `how to listen for Open edX Events`_ for more information. 
+
+Extension developers could interact with an essential part of the student's assessment lifecycle with these changes. But when none of these extension points are configured for use, then ORA assessments will behave as usual.
 
 Rejected Alternatives
 *********************


### PR DESCRIPTION
**TL;DR -** This PR adds an architectural decision record (ADR) justifying adding lightweight extension points in ORA during the submission lifecycle to solve this feature request: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3891855361/Assessment+step+with+external+tools+-+Turnitin

The ADR talks about sharing students' submission information with external services; in the feature request, that external service is Turnitin, a plagiarism tool. 

**What changed?**

- A new architectural decision record (ADR) was added by the name of:  0003-lightweight-extension-points.rst

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

You could follow these instructions if you want to test what's on the ADR. They are tailored to be used with the Turnitin tool, so you'll need credentials to integrate with it:

1. Install the repositories with the extension points implementations, which allow ORA to share the student's submission data with external services. As mentioned in the feature request, the external service, in this case, is Turnitin. 
```
pip install git+https://github.com/edunext/openedx-events@ora-extension-points
pip install git+https://github.com/edunext/openedx-filters@ora-extension-points
pip install git+https://github.com/edunext/edx-ora2@ora-extension-points
```
2. Configure the Open edX Filter in your environment. The event receiver will work out of the box after the next step.
```
    OPEN_EDX_FILTERS_CONFIG = {
      "org.openedx.learning.ora.submission_view.render.started.v1": {
        "fail_silently": False,
        "pipeline": [
          "platform_plugin_turnitin.extensions.filters.ORASubmissionViewTurnitinWarning",
        ]
      },
    }
```
3. Since we're sharing data with Turnitin, we must install the necessary tools to communicate with the service. Our team implemented a set of APIs in an Open edX plugin to do so, so installing the plugin will make those APIs available:
```
pip install git+https://github.com/eduNEXT/platform-plugin-turnitin.git
```
4. Now, configure your credentials:
```
    TURNITIN_TII_API_URL = "https://xyz-sandbox.com"
    TURNITIN_TCA_INTEGRATION_FAMILY = "xyz"
    TURNITIN_TCA_INTEGRATION_VERSION = "X.Y.Z"
    TURNITIN_TCA_API_KEY = "xyzw"
    TURNITIN_API_TIMEOUT = 30
```
Then, as a student, upload an assignment. Then, with the assignment ID, as an instructor, access the Turnitin API. Please use a bearer token as the authentication method as usual with Open edX APIs.

Generate similarity report for a submission given its submission ID:  
PUT https://{{lms_domain}}/platform-plugin-turnitin/{{course_id}}/api/v1/similarity-report/{{submission_id}}/

Get similarity report status for a submission given its submission ID:
GET https://{{lms_domain}}/platform-plugin-turnitin/{{course_id}}/api/v1/similarity-report/{{submission_id}}/

Get viewer URL for the report given the submission ID:
GET https://{{lms_domain}}/platform-plugin-turnitin/{{course_id}}/api/v1/viewer-url/{{submission_id}}/

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
