### PR TITLE
fix: increase item_id max lenght from 128 to 255 for peer, staff and studenttraining workflow

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.1.0'
+__version__ = '6.2.0'

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -18,7 +18,7 @@ from lazy import lazy
 from webob import Response
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchServiceError
-from xblock.fields import Boolean, Integer, List, Scope, String
+from xblock.fields import Boolean, Dict, Integer, List, Scope, String
 
 from openassessment.staffgrader.staff_grader_mixin import StaffGraderMixin
 from openassessment.workflow.errors import AssessmentWorkflowError
@@ -282,6 +282,9 @@ class OpenAssessmentBlock(
         scope=Scope.content,
         help="A title to display to a student (plain text)."
     )
+
+    xml_attributes = Dict(help="Map of unhandled xml attributes, used only for storage between import and export",
+                          default={}, scope=Scope.settings)
 
     white_listed_file_types = List(
         default=[],
@@ -934,6 +937,12 @@ class OpenAssessmentBlock(
         block.text_response_editor = config['text_response_editor']
         block.title = config['title']
         block.white_listed_file_types_string = config['white_listed_file_types']
+
+        # Deserialize and add tag data info to block if any
+        if hasattr(block, 'read_tags_from_node') and callable(block.read_tags_from_node):  # pylint: disable=no-member
+            # This comes from TaggedBlockMixin
+            block.read_tags_from_node(node)  # pylint: disable=no-member
+
         return block
 
     @property

--- a/openassessment/xblock/test/data/content_tags.xml
+++ b/openassessment/xblock/test/data/content_tags.xml
@@ -1,0 +1,93 @@
+<openassessment text_response="required" file_upload_response="" group_access="{&quot;381451918&quot;: [1179773159]}" prompts_type="text" tags-v1="test content tags">
+    <title>Open Assessment Test</title>
+    <prompts>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat poverty? Please answer in a short essay of 200-300 words.</description>
+        </prompt>
+        <prompt>
+            <description>Given the state of the world today, what do you think should be done to combat pollution?</description>
+        </prompt>
+    </prompts>
+    <rubric>
+        <criterion>
+            <name>Concise</name>
+            <prompt>How concise is it?</prompt>
+            <option points="0">
+                <name>Neal Stephenson (late)</name>
+                <explanation>Neal Stephenson explanation</explanation>
+            </option>
+            <option points="1">
+                <name>HP Lovecraft</name>
+                <explanation>HP Lovecraft explanation</explanation>
+            </option>
+            <option points="3">
+                <name>Robert Heinlein</name>
+                <explanation>Robert Heinlein explanation</explanation>
+            </option>
+            <option points="4">
+                <name>Neal Stephenson (early)</name>
+                <explanation>Neal Stephenson (early) explanation</explanation>
+            </option>
+            <option points="5">
+                <name>Earnest Hemingway</name>
+                <explanation>Earnest Hemingway</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Clear-headed</name>
+            <prompt>How clear is the thinking?</prompt>
+            <option points="0">
+                <name>Yogi Berra</name>
+                <explanation>Yogi Berra explanation</explanation>
+            </option>
+            <option points="1">
+                <name>Hunter S. Thompson</name>
+                <explanation>Hunter S. Thompson explanation</explanation>
+            </option>
+            <option points="2">
+                <name>Robert Heinlein</name>
+                <explanation>Robert Heinlein explanation</explanation>
+            </option>
+            <option points="3">
+                <name>Isaac Asimov</name>
+                <explanation>Isaac Asimov explanation</explanation>
+            </option>
+            <option points="10">
+                <name>Spock</name>
+                <explanation>Spock explanation</explanation>
+            </option>
+        </criterion>
+        <criterion>
+            <name>Form</name>
+            <prompt>Lastly, how is its form? Punctuation, grammar, and spelling all count.</prompt>
+            <option points="0">
+                <name>lolcats</name>
+                <explanation>lolcats explanation</explanation>
+            </option>
+            <option points="1">
+                <name>Facebook</name>
+                <explanation>Facebook explanation</explanation>
+            </option>
+            <option points="2">
+                <name>Reddit</name>
+                <explanation>Reddit explanation</explanation>
+            </option>
+            <option points="3">
+                <name>metafilter</name>
+                <explanation>metafilter explanation</explanation>
+            </option>
+            <option points="4">
+                <name>Usenet, 1996</name>
+                <explanation>Usenet, 1996 explanation</explanation>
+            </option>
+            <option points="5">
+                <name>The Elements of Style</name>
+                <explanation>The Elements of Style explanation</explanation>
+            </option>
+        </criterion>
+    </rubric>
+    <assessments>
+        <assessment name="peer-assessment" must_grade="5" must_be_graded_by="3" />
+        <assessment name="self-assessment" />
+    </assessments>
+</openassessment>


### PR DESCRIPTION
**TL;DR -** [ A short summary of what this PR does and why ]
The current max length for item_id fields of peerworkflow, staffworkflow and studenttrainingworkflow is 128 characters which are insufficient for course_id with a length greater than 70 characters. This PR alters the max length of item_id from 128 to 255.

**What changed?**

- Increase item_id max length of peerworkflow, staffworkflow and studenttrainingworkflow  from 128 to 255.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

- Check if the definitions of these fields are varchar(255). openedx.assessment_peerworkflow.item_id, openedx.assessment_staffworkflow.item_id and openedx.assessment_studenttrainingworkflow.item_id.
- Create a new course with an  ID > 70 characters.
- Create an Open Response component that has Student training and Peer and Staff steps.
- Submit responses and assess them.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
