### PR TITLE
chore: stop esg url to show up when the environment is not defined

### DIFF
--- a/openassessment/templates/legacy/staff_area/oa_staff_area.html
+++ b/openassessment/templates/legacy/staff_area/oa_staff_area.html
@@ -12,12 +12,12 @@
         </button>
         <button class="ui-staff__button button-staff-info" aria-expanded="false" data-panel="openassessment__staff-info">{% trans "View Assignment Statistics" %}</button>
         {% if staff_assessment_required %}
-            {% if is_enhanced_staff_grader_enabled %}
+            {% if is_enhanced_staff_grader_enabled and enhanced_staff_grader_url %}
                 <a href="{{enhanced_staff_grader_url}}" class="ui-staff__button button-enhanced-staff-grader" aria-expanded="false">{% trans "Grade Available Responses" %} <span class="icon fa fa-external-link" aria-hidden="true"></span></a>
             {% else %}
                 <button class="ui-staff__button button-staff-grading" aria-expanded="false" data-panel="openassessment__staff-grading">{% trans "Grade Available Responses" %}</button>
                 {% comment %} Remove if block in AU-617 {% endcomment %}
-                {% if not is_team_assignment %}
+                {% if not is_team_assignment and enhanced_staff_grader_url %}
                     <a href="{{enhanced_staff_grader_url}}" class="ui-staff__button button-enhanced-staff-grader button-enhanced-staff-grader-demo" aria-expanded="false">{% trans "Demo the new Grading Experience" %} <span class="icon fa fa-external-link" aria-hidden="true"></span></a>
                 {% endif %}
             {% endif %}

--- a/openassessment/xblock/staff_area_mixin.py
+++ b/openassessment/xblock/staff_area_mixin.py
@@ -145,10 +145,9 @@ class StaffAreaMixin:
                 context['is_enhanced_staff_grader_enabled'] = False
             else:
                 context['is_enhanced_staff_grader_enabled'] = self.is_enhanced_staff_grader_enabled
-            context['enhanced_staff_grader_url'] = '{esg_url}/{block_id}'.format(
-                esg_url=getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', ''),
-                block_id=str(self.get_xblock_id())
-            )
+
+            esg_url = getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', None)
+            context['enhanced_staff_grader_url'] = f'{esg_url}/{str(self.get_xblock_id())}' if esg_url else None
 
             context.update(
                 self.get_staff_assessment_statistics_context(student_item["course_id"], student_item["item_id"])

--- a/openassessment/xblock/test/test_staff_area.py
+++ b/openassessment/xblock/test/test_staff_area.py
@@ -1337,6 +1337,25 @@ class TestCourseStaff(XBlockHandlerTestCase):
             esg_url='ora_url',
             block_id=context['xblock_id']
         ))
+    
+    @override_settings(
+        ORA_GRADING_MICROFRONTEND_URL=None
+    )
+    @patch(
+        'openassessment.xblock.config_mixin.ConfigMixin.is_enhanced_staff_grader_enabled',
+        new_callable=PropertyMock
+    )
+    @scenario('data/staff_grade_scenario.xml', user_id='Bob')
+    def test_staff_area_esg_no_url(self, xblock, mock_esg_flag):
+        """
+        If there is a staff step, enhanced_staff_grader_url should be None
+        if ORA_GRADING_MICROFRONTEND_URL is not set
+        """
+        mock_esg_flag.return_value = True
+        _, context = xblock.get_staff_path_and_context()
+        self._verify_staff_assessment_context(context, True, 0, 0)
+        self.assertEqual(context['is_enhanced_staff_grader_enabled'], True)
+        self.assertIsNone(context['enhanced_staff_grader_url'])
 
     @log_capture()
     @patch('openassessment.xblock.config_mixin.ConfigMixin.user_state_upload_data_enabled')


### PR DESCRIPTION
**TL;DR -** [ A short summary of what this PR does and why ]

JIRA: [JIRA-XXXX](https://openedx.atlassian.net/browse/JIRA-XXXX)

**What changed?**

- [ More in depth breakdown of changes ]
- [ Peripheral things that got changed ]
- [ etc... ]

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
