### PR TITLE
build: Update codecov and use the new token.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
 
     - name: Run Coverage
       if: matrix.python-version == '3.8' && matrix.toxenv=='django42'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         flags: unittests
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Newer versions of codecov require a repo specific token to publish
coverage reports.  The older versions don't but are failing more often
as they prepare to drop support for them. As a part of this change a
the token was added as a repository actions secret.
