### PR TITLE
fix: use get to avoid key error

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.11.0'
+__version__ = '6.11.1'

--- a/openassessment/xblock/utils/validation.py
+++ b/openassessment/xblock/utils/validation.py
@@ -168,7 +168,7 @@ def validate_assessments(assessments, current_assessments, is_released, _):
         if names != current_names:
             return False, _("The assessment type cannot be changed after the problem has been released.")
 
-        if settings.FEATURES["ENABLE_ORA_PEER_CONFIGURABLE_GRADING"]:
+        if settings.FEATURES.get("ENABLE_ORA_PEER_CONFIGURABLE_GRADING"):
             grading_strategies = [assessment.get('grading_strategy') for assessment in assessments]
             current_grading_strategies = [assessment.get('grading_strategy') for assessment in current_assessments]
             if grading_strategies != current_grading_strategies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.11.0",
+  "version": "6.11.1",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
** If the environment doesn't have ENABLE_ORA_PEER_CONFIGURABLE_GRADING defined this line will throw a keyerror

- Note: I don't know why  it isn't defined? It looks like it should be? Nevertheless the error is thrown. Investigation for another time.

JIRA: [CR-6800](https://2u-internal.atlassian.net/browse/CR-6800)

FYI: @openedx/content-aurora
