### PR TITLE
feat: make lease expiration times configurable

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.12.1'
+__version__ = '6.12.2'

--- a/openassessment/assessment/models/peer.py
+++ b/openassessment/assessment/models/peer.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 import logging
 import random
 
+from django.conf import settings
 from django.db import DatabaseError, models
 from django.utils.timezone import now
 
@@ -108,7 +109,7 @@ class PeerWorkflow(models.Model):
 
     """
     # Amount of time before a lease on a submission expires
-    TIME_LIMIT = timedelta(hours=8)
+    TIME_LIMIT = timedelta(hours=getattr(settings, "ORA_PEER_LEASE_EXPIRATION_HOURS", 8))
 
     student_id = models.CharField(max_length=40, db_index=True)
     item_id = models.CharField(max_length=255, db_index=True)

--- a/openassessment/assessment/models/staff.py
+++ b/openassessment/assessment/models/staff.py
@@ -6,6 +6,7 @@ Models for managing staff assessments.
 from datetime import timedelta
 import logging
 
+from django.conf import settings
 from django.db import DatabaseError, models
 from django.utils.timezone import now
 
@@ -28,7 +29,7 @@ class StaffWorkflow(models.Model):
 
     """
     # Amount of time before a lease on a submission expires
-    TIME_LIMIT = timedelta(hours=8)
+    TIME_LIMIT = timedelta(hours=getattr(settings, "ORA_STAFF_LEASE_EXPIRATION_HOURS", 8))
 
     scorer_id = models.CharField(max_length=40, db_index=True, blank=True)
     course_id = models.CharField(max_length=255, db_index=True)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.12.1",
+  "version": "6.12.2",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
# Description

By default, ORA hands off an assignment for which a peer review hasn’t been submitted to the next learner after 8 hours - some learners start a peer review, then come back the next morning and find the response gone. This PR makes lease expiration times configurable, thus preventing responses from disappearing if they're set to 24 hours, for example.

# Testing instructions

1. Set both settings to `1`.
2. Start a peer review, but don't submit anything.
3. After an hour, verify that your assignment has been handed off.

[private-ref](https://tasks.opencraft.com/browse/BB-8990)