### PR TITLE
fix: course name missing from ORA notification context

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.11.1'
+__version__ = '6.11.2'

--- a/openassessment/xblock/test/test_notifications.py
+++ b/openassessment/xblock/test/test_notifications.py
@@ -2,7 +2,7 @@
 Unit test for notification util
 """
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from openassessment.xblock.utils.notifications import send_staff_notification
 
@@ -11,8 +11,9 @@ class TestSendStaffNotification(unittest.TestCase):
     """
     Test for send_staff_notification function
     """
+    @patch('openassessment.xblock.utils.notifications.modulestore')
     @patch('openassessment.xblock.utils.notifications.COURSE_NOTIFICATION_REQUESTED.send_event')
-    def test_send_staff_notification(self, mock_send_event):
+    def test_send_staff_notification(self, mock_send_event, mocked_modulestore):
         """
         Test send_staff_notification function
         """
@@ -20,6 +21,8 @@ class TestSendStaffNotification(unittest.TestCase):
         course_id = 'course_id'
         problem_id = 'problem_id'
         ora_name = 'ora_name'
+
+        mocked_modulestore.return_value = MagicMock()
 
         # Call the function
         send_staff_notification(course_id, problem_id, ora_name)
@@ -37,9 +40,10 @@ class TestSendStaffNotification(unittest.TestCase):
         self.assertEqual(notification_data.app_name, "grading")
         self.assertEqual(notification_data.audience_filters['course_roles'], ['staff', 'instructor'])
 
+    @patch('openassessment.xblock.utils.notifications.modulestore')
     @patch('openassessment.xblock.utils.notifications.logger.error')
     @patch('openassessment.xblock.utils.notifications.COURSE_NOTIFICATION_REQUESTED.send_event')
-    def test_send_staff_notification_error_logging(self, mock_send_event, mock_logger_error):
+    def test_send_staff_notification_error_logging(self, mock_send_event, mock_logger_error, mocked_modulestore):
         """
         Test send_staff_notification function when an exception is raised
         """
@@ -47,6 +51,8 @@ class TestSendStaffNotification(unittest.TestCase):
         course_id = 'course_id'
         problem_id = 'problem_id'
         ora_name = 'ora_name'
+
+        mocked_modulestore.return_value = MagicMock()
 
         # Mock exception
         mock_exception = Exception('Test exception')

--- a/openassessment/xblock/utils/notifications.py
+++ b/openassessment/xblock/utils/notifications.py
@@ -6,7 +6,7 @@ import logging
 from django.conf import settings
 from openedx_events.learning.signals import COURSE_NOTIFICATION_REQUESTED
 from openedx_events.learning.data import CourseNotificationData
-from xmodule.modulestore.django import modulestore
+from openassessment.runtime_imports.functions import modulestore
 
 logger = logging.getLogger(__name__)
 

--- a/openassessment/xblock/utils/notifications.py
+++ b/openassessment/xblock/utils/notifications.py
@@ -6,6 +6,7 @@ import logging
 from django.conf import settings
 from openedx_events.learning.signals import COURSE_NOTIFICATION_REQUESTED
 from openedx_events.learning.data import CourseNotificationData
+from xmodule.modulestore.django import modulestore
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +19,12 @@ def send_staff_notification(course_id, problem_id, ora_name):
         audience_filters = {
             'course_roles': ['staff', 'instructor']
         }
+        course = modulestore().get_course(course_id)
         notification_data = CourseNotificationData(
             course_key=course_id,
             content_context={
-                'ora_name': ora_name
+                'ora_name': ora_name,
+                'course_name': course.display_name,
             },
             notification_type='ora_staff_notification',
             content_url=f"{getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', '')}/{problem_id}",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.11.1",
+  "version": "6.11.2",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",


### PR DESCRIPTION
Ticket: [INF-1462](https://2u-internal.atlassian.net/browse/INF-1462)

The course name was missing from the context of the ORA notification. 

### Before:
<img width="556" alt="image-20240709-072858" src="https://github.com/user-attachments/assets/a7f940ae-438c-495c-84fd-3d6314ff53eb">

### After:
<img width="550" alt="Screenshot 2024-07-31 at 11 48 04 AM" src="https://github.com/user-attachments/assets/8056549d-93f8-4c72-bed4-eb0f05d8f6be">
