### PR TITLE
Optimize _build_feedback_options_cells

### DIFF
--- a/openassessment/data.py
+++ b/openassessment/data.py
@@ -597,14 +597,9 @@ class OraAggregateData:
         Returns:
             string that should be included in the relevant 'feedback_options' column for this set of assessments' row
         """
-
-        returned_string = ""
-        for assessment in assessments:
-            for feedback in assessment.assessment_feedback.all():
-                for option in feedback.options.all():
-                    returned_string += option.text + "\n"
-
-        return returned_string
+        return '\n'.join(Assessment.objects
+                     .filter(id__in=(a.id for a in assessments), assessment_feedback__options__text__isnull=False)
+                     .values_list('assessment_feedback__options__text', flat=True))
 
     @classmethod
     def _build_feedback_cell(cls, submission_uuid):


### PR DESCRIPTION
**TL;DR -** The function have been rewrited to perform exactly one query. Also, the join function was used to avoid string copying.

**What changed?**

- x200 speed up
- The last line delimiter is absent now. (Do not know whether it is important)

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

Unit test should pass, since the behaviour is the same.

**Benchmarking**
```python
assessments = Assessment.objects.all()[:1000]
timeit('old(assessments)', globals=locals(), number=10) * 100
# 1029.1335321962833  # milliseconds
timeit('new(assessments)', globals=locals(), number=10) * 100
# 6.815670058131218 # milliseconds
```

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
