### PR TITLE
test: Add Node 20 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.11']
-        node-version: [18]
+        node-version: [18, 20]
         toxenv: [quality, js, django42]
+    continue-on-error: ${{ matrix.node == 20 }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### Description

As a first step in the upgrade to Node 20, add it to the CI matrix as a non-blocking test.

See [the tracking issue](https://github.com/openedx/edx-ora2/issues/2242) for further information.