### PR TITLE
fix: use legacy view for studio teams ORA

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.14.0'
+__version__ = '6.14.1'

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -594,7 +594,7 @@ class OpenAssessmentBlock(
             context_dict,
             initialize_js_func='OpenAssessmentBlock',
             additional_js_context={
-                "MFE_VIEW_ENABLED": self.mfe_views_enabled,
+                "MFE_VIEW_ENABLED": self.mfe_views_enabled and self.mfe_views_supported,
                 "ORA_MICROFRONTEND_URL": getattr(settings, 'ORA_MICROFRONTEND_URL', ''),
                 "IS_STUDIO": True,
             }


### PR DESCRIPTION
**TL;DR -** Open Response Assessment with teams shows error in studio because the new UI doesn't currently support Team assessments. This PR updates the code to use the legacy UI for teams assessment in studio.

JIRA: [AU-2271](https://2u-internal.atlassian.net/browse/AU-2271)

**What changed?**

- Update studio teams view to use legacy UI

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
