### PR TITLE
rename aria-labeledby to aria-labelledby

### DIFF
--- a/openassessment/templates/legacy/grade/oa_grade_cancelled.html
+++ b/openassessment/templates/legacy/grade/oa_grade_cancelled.html
@@ -3,7 +3,7 @@
 <li id="openassessment__grade__{{ xblock_id }}" class="openassessment__steps__step step--grade is--initially--collapsed  has--error ui-slidable__container" tabindex="-1">
     <header class="step__header ui-slidable__control">
         <span>
-            <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
+            <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labelledby="oa_step_title_grade">
                 <span class="icon fa fa-caret-right" aria-hidden="false"/>
             </button>
         </span>

--- a/openassessment/templates/legacy/grade/oa_grade_complete.html
+++ b/openassessment/templates/legacy/grade/oa_grade_complete.html
@@ -3,7 +3,7 @@
     <li id="openassessment__grade__{{ xblock_id }}" class="openassessment__steps__step step--grade is--complete is--showing has--grade ui-slidable__container {% if allow_latex %}allow--latex{% endif %}" tabindex="-1">
         <header class="step__header ui-slidable__control">
             <span>
-                <button class="ui-slidable" aria-expanded="true" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
+                <button class="ui-slidable" aria-expanded="true" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labelledby="oa_step_title_grade">
                     <span class="icon fa fa-caret-right" aria-hidden="false"/>
                 </button>
             </span>

--- a/openassessment/templates/legacy/grade/oa_grade_incomplete.html
+++ b/openassessment/templates/legacy/grade/oa_grade_incomplete.html
@@ -3,7 +3,7 @@
 <li id="openassessment__grade__{{ xblock_id }}" class="openassessment__steps__step step--grade is--unfinished is--initially--collapsed  ui-slidable__container" tabindex="-1">
     <header class="step__header ui-slidable__control">
         <span>
-            <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
+            <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labelledby="oa_step_title_grade">
                 <span class="icon fa fa-caret-right" aria-hidden="false"/>
             </button>
         </span>

--- a/openassessment/templates/legacy/grade/oa_grade_not_started.html
+++ b/openassessment/templates/legacy/grade/oa_grade_not_started.html
@@ -3,7 +3,7 @@
 <li id="openassessment__grade__{{ xblock_id }}" class="openassessment__steps__step step--grade is--unstarted is--initially--collapsed  ui-slidable__container" tabindex="-1">
     <header class="step__header ui-slidable__control">
         <span>
-            <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
+            <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labelledby="oa_step_title_grade">
                 <span class="icon fa fa-caret-right" aria-hidden="false"/>
             </button>
         </span>

--- a/openassessment/templates/legacy/grade/oa_grade_waiting.html
+++ b/openassessment/templates/legacy/grade/oa_grade_waiting.html
@@ -3,7 +3,7 @@
 <li id="openassessment__grade__{{ xblock_id }}" class="openassessment__steps__step step--grade is--showing {{ is_waiting_staff }} ui-slidable__container" tabindex="-1">
     <header class="step__header ui-slidable__control">
         <span>
-            <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labeledby="oa_step_title_grade">
+            <button class="ui-slidable" aria-expanded="false" id="oa_grade_{{ xblock_id }}" aria-controls="oa_grade_{{ xblock_id }}_content" aria-labelledby="oa_step_title_grade">
                 <span class="icon fa fa-caret-right" aria-hidden="false"/>
             </button>
         </span>

--- a/openassessment/templates/legacy/peer/oa_peer_assessment.html
+++ b/openassessment/templates/legacy/peer/oa_peer_assessment.html
@@ -23,7 +23,7 @@
     <header class="step__header ui-slidable__control">
         <span>
             {% block button %}
-                <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
+                <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labelledby="oa_step_title_peer">
                     <span class="icon fa fa-caret-right" aria-hidden="false"/>
                 </button>
             {% endblock %}

--- a/openassessment/templates/legacy/peer/oa_peer_closed.html
+++ b/openassessment/templates/legacy/peer/oa_peer_closed.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
+    <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labelledby="oa_step_title_peer">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/peer/oa_peer_complete.html
+++ b/openassessment/templates/legacy/peer/oa_peer_complete.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="false" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
+    <button class="ui-slidable" aria-expanded="false" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labelledby="oa_step_title_peer">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/peer/oa_peer_turbo_mode.html
+++ b/openassessment/templates/legacy/peer/oa_peer_turbo_mode.html
@@ -12,7 +12,7 @@
 
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
+    <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labelledby="oa_step_title_peer">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/peer/oa_peer_turbo_mode_waiting.html
+++ b/openassessment/templates/legacy/peer/oa_peer_turbo_mode_waiting.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
+    <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labelledby="oa_step_title_peer">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/peer/oa_peer_waiting.html
+++ b/openassessment/templates/legacy/peer/oa_peer_waiting.html
@@ -7,7 +7,7 @@
 
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labeledby="oa_step_title_peer">
+    <button class="ui-slidable" aria-expanded="true" id="oa_peer_{{ xblock_id }}" aria-controls="oa_peer_{{ xblock_id }}_content" aria-labelledby="oa_step_title_peer">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/response/oa_response.html
+++ b/openassessment/templates/legacy/response/oa_response.html
@@ -9,7 +9,7 @@
     <header class="step__header ui-slidable__control">
         <span>
             {% block button %}
-                <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
+                <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labelledby="oa_step_title_response">
                     <span class="icon fa fa-caret-right" aria-hidden="false"/>
                 </button>
             {% endblock %}

--- a/openassessment/templates/legacy/response/oa_response_cancelled.html
+++ b/openassessment/templates/legacy/response/oa_response_cancelled.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
+    <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labelledby="oa_step_title_response">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/response/oa_response_closed.html
+++ b/openassessment/templates/legacy/response/oa_response_closed.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
+    <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labelledby="oa_step_title_response">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/response/oa_response_graded.html
+++ b/openassessment/templates/legacy/response/oa_response_graded.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
+    <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labelledby="oa_step_title_response">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/response/oa_response_submitted.html
+++ b/openassessment/templates/legacy/response/oa_response_submitted.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labeledby="oa_step_title_response">
+    <button class="ui-slidable" aria-expanded="true" id="oa_response_{{ xblock_id }}" aria-controls="oa_response_{{ xblock_id }}_content" aria-labelledby="oa_step_title_response">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/self/oa_self_assessment.html
+++ b/openassessment/templates/legacy/self/oa_self_assessment.html
@@ -20,7 +20,7 @@
     <header class="step__header ui-slidable__control">
         <span>
             {% block button %}
-                <button class="ui-slidable" aria-expanded="true" id="oa_self_{{ xblock_id }}" aria-controls="oa_self_{{ xblock_id }}_content" aria-labeledby="oa_step_title_self">
+                <button class="ui-slidable" aria-expanded="true" id="oa_self_{{ xblock_id }}" aria-controls="oa_self_{{ xblock_id }}_content" aria-labelledby="oa_step_title_self">
                     <span class="icon fa fa-caret-right" aria-hidden="false"/>
                 </button>
             {% endblock %}

--- a/openassessment/templates/legacy/self/oa_self_cancelled.html
+++ b/openassessment/templates/legacy/self/oa_self_cancelled.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="false" aria-labeledby="oa_step_title_self" disabled/>
+    <button class="ui-slidable" aria-expanded="false" aria-labelledby="oa_step_title_self" disabled/>
 {% endblock %}
 
 {% block title %}

--- a/openassessment/templates/legacy/self/oa_self_closed.html
+++ b/openassessment/templates/legacy/self/oa_self_closed.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="true" id="oa_self_{{ xblock_id }}" aria-controls="oa_self_{{ xblock_id }}_content" aria-labeledby="oa_step_title_self">
+    <button class="ui-slidable" aria-expanded="true" id="oa_self_{{ xblock_id }}" aria-controls="oa_self_{{ xblock_id }}_content" aria-labelledby="oa_step_title_self">
         <span class="icon fa fa-caret-right" aria-hidden="false"/>
     </button>
 {% endblock %}

--- a/openassessment/templates/legacy/self/oa_self_complete.html
+++ b/openassessment/templates/legacy/self/oa_self_complete.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="false" aria-labeledby="oa_step_title_self" disabled/>
+    <button class="ui-slidable" aria-expanded="false" aria-labelledby="oa_step_title_self" disabled/>
 {% endblock %}
 
 {% block title %}

--- a/openassessment/templates/legacy/self/oa_self_unavailable.html
+++ b/openassessment/templates/legacy/self/oa_self_unavailable.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block button %}
-    <button class="ui-slidable" aria-expanded="false" aria-labeledby="oa_step_title_self" disabled/>
+    <button class="ui-slidable" aria-expanded="false" aria-labelledby="oa_step_title_self" disabled/>
 {% endblock %}
 
 {% block title %}


### PR DESCRIPTION
**TL;DR -** Renames all uses of `aria-labeledby` to `aria-labelledby`.

I'm making this change because the `aria-labeledby` (with a single `l` in the middle) is the alternate spelling to the correct `aria-labelledby` (with two `l`s in the middle). The two `l`s version is preferred over the single `l` version. Some browsers will only respect the version with two `l`s. 

I discovered this repository by performing a code search for uses of `aria-labeledby` and sending PRs to replace them. (I'm not a bot but someone who is working on fixing this issue). For more on this you could read https://github.com/w3c/aria/issues/2093.

JIRA: (none)

**What changed?**

- All `aria-labeledby` attributes have changed to `aria-labelledby`.

**Developer Checklist**

- [ ] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [ ] Translations and JS/SASS compiled
- [ ] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
