### PR TITLE
feat: Group ora staff notifications

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.14.8'
+__version__ = '6.15.0'

--- a/openassessment/xblock/apis/submissions/submissions_actions.py
+++ b/openassessment/xblock/apis/submissions/submissions_actions.py
@@ -168,10 +168,15 @@ def create_submission(
             course_id = block_config_data.course.id
         else:
             course_id = CourseKey.from_string(student_item_dict.get("course_id"))
+
+        usage_id = block_config_data._block.scope_ids.usage_id  # pylint: disable=protected-access
+        group_by_id = getattr(usage_id, "block_id", '')
+
         send_staff_notification(
             course_id,
             student_item_dict.get("item_id"),
-            block_config_data._block.display_name  # pylint: disable=protected-access
+            block_config_data._block.display_name,  # pylint: disable=protected-access
+            group_by_id
         )
 
     # Emit analytics event...

--- a/openassessment/xblock/utils/notifications.py
+++ b/openassessment/xblock/utils/notifications.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-def send_staff_notification(course_id, problem_id, ora_name):
+def send_staff_notification(course_id, problem_id, ora_name, group_by_id=''):
     """
     Send a staff notification for a course
     """
@@ -32,6 +32,7 @@ def send_staff_notification(course_id, problem_id, ora_name):
             content_context={
                 'ora_name': ora_name,
                 'course_name': course.display_name,
+                'group_by_id': group_by_id
             },
             notification_type='ora_staff_notification',
             content_url=f"{getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', '')}/{problem_id}",


### PR DESCRIPTION
Ticket
https://2u-internal.atlassian.net/browse/INF-1838

Description
To implement group notifications for staff regarding ORA submissions, we need to use the block_id as the group_id to group notifications accordingly.