### PR TITLE
fix: Update course preference notification key for ORA new submission

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.15.0'
+__version__ = '6.15.1'

--- a/openassessment/xblock/test/test_notifications.py
+++ b/openassessment/xblock/test/test_notifications.py
@@ -42,7 +42,7 @@ class TestSendStaffNotification(unittest.TestCase):
         # Check if CourseNotificationData is properly initialized
         self.assertEqual(notification_data.course_key, course_id)
         self.assertEqual(notification_data.content_context['ora_name'], ora_name)
-        self.assertEqual(notification_data.notification_type, 'ora_staff_notification')
+        self.assertEqual(notification_data.notification_type, 'ora_staff_notifications')
         self.assertEqual(notification_data.content_url, f"/{problem_id}")
         self.assertEqual(notification_data.app_name, "grading")
         self.assertEqual(notification_data.audience_filters['course_roles'], ['staff', 'instructor'])

--- a/openassessment/xblock/utils/notifications.py
+++ b/openassessment/xblock/utils/notifications.py
@@ -34,7 +34,7 @@ def send_staff_notification(course_id, problem_id, ora_name, group_by_id=''):
                 'course_name': course.display_name,
                 'group_by_id': group_by_id
             },
-            notification_type='ora_staff_notification',
+            notification_type='ora_staff_notifications',
             content_url=f"{getattr(settings, 'ORA_GRADING_MICROFRONTEND_URL', '')}/{problem_id}",
             app_name="grading",
             audience_filters=audience_filters,


### PR DESCRIPTION


**What changed?**
In this PR we have updated the course notification preference key for ORA new submissions , As we have updated the key on backend

**Ticket**
https://2u-internal.atlassian.net/browse/INF-1838

