### PR TITLE
chore: support upgrading to django 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12"]
-        toxenv: [quality, js, django42]
+        toxenv: [quality, js, django42, django52]
 
     steps:
       - uses: actions/checkout@v4

--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '6.15.1'
+__version__ = '6.16.0'

--- a/openassessment/assessment/admin.py
+++ b/openassessment/assessment/admin.py
@@ -16,6 +16,7 @@ from openassessment.assessment.models import (
 from openassessment.assessment.serializers import RubricSerializer
 
 
+@admin.register(Rubric)
 class RubricAdmin(admin.ModelAdmin):
     """
     Django admin model for Rubrics.
@@ -55,6 +56,7 @@ class PeerWorkflowItemInline(admin.StackedInline):
     extra = 0
 
 
+@admin.register(PeerWorkflow)
 class PeerWorkflowAdmin(admin.ModelAdmin):
     """
     Django admin model for PeerWorkflows.
@@ -69,6 +71,7 @@ class PeerWorkflowAdmin(admin.ModelAdmin):
     inlines = (PeerWorkflowItemInline,)
 
 
+@admin.register(Assessment)
 class AssessmentAdmin(admin.ModelAdmin):
     """
     Django admin model for Assessments.
@@ -88,6 +91,10 @@ class AssessmentAdmin(admin.ModelAdmin):
     )
     exclude = ('rubric', 'submission_uuid')
 
+    @admin.display(
+        description='Rubric',
+        ordering='rubric__content_hash',
+    )
     def rubric_link(self, assessment_obj):
         """
         Returns the rubric link for this assessment.
@@ -98,8 +105,6 @@ class AssessmentAdmin(admin.ModelAdmin):
         )
         return format_html(
             '<a href="{}">{}</a>', url, assessment_obj.rubric.content_hash)
-    rubric_link.admin_order_field = 'rubric__content_hash'
-    rubric_link.short_description = 'Rubric'
 
     def parts_summary(self, assessment_obj):
         """
@@ -116,6 +121,7 @@ class AssessmentAdmin(admin.ModelAdmin):
         ) for part in assessment_obj.parts.all()))
 
 
+@admin.register(AssessmentFeedback)
 class AssessmentFeedbackAdmin(admin.ModelAdmin):
     """
     Django admin model for AssessmentFeedbacks.
@@ -137,6 +143,7 @@ class AssessmentFeedbackAdmin(admin.ModelAdmin):
         ))
 
 
+@admin.register(SharedFileUpload)
 class SharedFileUploadAdmin(admin.ModelAdmin):
     """
     Django admin model for SharedFileUploads.
@@ -151,6 +158,7 @@ class SharedFileUploadAdmin(admin.ModelAdmin):
     )
 
 
+@admin.register(StaffWorkflow)
 class StaffWorkflowAdmin(admin.ModelAdmin):
     """
     Django admin model for StaffWorkflows
@@ -158,17 +166,9 @@ class StaffWorkflowAdmin(admin.ModelAdmin):
     list_display = ('id', 'submission_uuid', 'course_id', 'item_id', 'grading_completed_at')
 
 
+@admin.register(TeamStaffWorkflow)
 class TeamStaffWorkflowAdmin(admin.ModelAdmin):
     """
     Django admin model for TeamStaffWorkflows
     """
     list_display = ('id', 'team_submission_uuid', 'course_id', 'item_id', 'grading_completed_at')
-
-
-admin.site.register(Rubric, RubricAdmin)
-admin.site.register(PeerWorkflow, PeerWorkflowAdmin)
-admin.site.register(Assessment, AssessmentAdmin)
-admin.site.register(AssessmentFeedback, AssessmentFeedbackAdmin)
-admin.site.register(SharedFileUpload, SharedFileUploadAdmin)
-admin.site.register(StaffWorkflow, StaffWorkflowAdmin)
-admin.site.register(TeamStaffWorkflow, TeamStaffWorkflowAdmin)

--- a/openassessment/assessment/urls.py
+++ b/openassessment/assessment/urls.py
@@ -1,12 +1,12 @@
 """ Assessment Urls. """
 
-from django.urls import re_path
+from django.urls import path
 
 from openassessment.assessment import views
 
 urlpatterns = [
-    re_path(
-        r'^(?P<student_id>[^/]+)/(?P<course_id>[^/]+)/(?P<item_id>[^/]+)$',
+    path(
+        '<str:student_id>/<str:course_id>/<str:item_id>',
         views.get_evaluations_for_student_item
     ),
 ]

--- a/openassessment/fileupload/urls.py
+++ b/openassessment/fileupload/urls.py
@@ -1,12 +1,12 @@
 """ Urls for fileupload app. """
 
-from django.urls import re_path
+from django.urls import path
 
 from openassessment.fileupload import views_django_storage, views_filesystem
 
 urlpatterns = [
-    re_path(r'^django/(?P<key>.+)/$', views_django_storage.django_storage,
-            name='openassessment-django-storage'),
-    re_path(r'^(?P<key>.+)/$', views_filesystem.filesystem_storage,
-            name='openassessment-filesystem-storage'),
+    path('django/<path:key>/', views_django_storage.django_storage,
+         name='openassessment-django-storage'),
+    path('<path:key>/', views_filesystem.filesystem_storage,
+         name='openassessment-filesystem-storage'),
 ]

--- a/openassessment/fileupload/views_filesystem.py
+++ b/openassessment/fileupload/views_filesystem.py
@@ -64,10 +64,10 @@ def get_content_metadata(request):
     """
 
     metadata = {
-        "Content-Type": request.META["CONTENT_TYPE"],
+        "Content-Type": request.headers["content-type"],
         "Date": str(timezone.now()),
         "Content-MD5": hashlib.md5(request.body).hexdigest(),
-        "Content-Length": request.META["CONTENT_LENGTH"],
+        "Content-Length": request.headers["content-length"],
     }
     return request.body, metadata
 

--- a/openassessment/staffgrader/admin.py
+++ b/openassessment/staffgrader/admin.py
@@ -6,6 +6,7 @@ from django.contrib import admin
 from openassessment.staffgrader.models import SubmissionGradingLock
 
 
+@admin.register(SubmissionGradingLock)
 class SubmissionGradingLockAdmin(admin.ModelAdmin):
     """
     Django admin model for SubmissionGradingLock.
@@ -15,9 +16,8 @@ class SubmissionGradingLockAdmin(admin.ModelAdmin):
     search_fields = ('submission_uuid',)
 
     # This allows us to have the nice boolean check/x icons in the list rather than "True"/"False"
+    @admin.display(
+        boolean=True
+    )
     def is_active(self, lock):
         return lock.is_active
-    is_active.boolean = True
-
-
-admin.site.register(SubmissionGradingLock, SubmissionGradingLockAdmin)

--- a/openassessment/workflow/admin.py
+++ b/openassessment/workflow/admin.py
@@ -12,6 +12,7 @@ class AssessmentWorkflowStepInline(admin.StackedInline):
     extra = 0
 
 
+@admin.register(AssessmentWorkflow)
 class AssessmentWorkflowAdmin(admin.ModelAdmin):
     """Admin for the user's overall workflow through open assessment.
 
@@ -28,6 +29,7 @@ class AssessmentWorkflowAdmin(admin.ModelAdmin):
     inlines = (AssessmentWorkflowStepInline,)
 
 
+@admin.register(TeamAssessmentWorkflow)
 class TeamAssessmentWorkflowAdmin(admin.ModelAdmin):
     """
     Admin for TeamAssessmentWorkflows.
@@ -40,7 +42,3 @@ class TeamAssessmentWorkflowAdmin(admin.ModelAdmin):
     search_fields = ('team_submission_uuid', 'submission_uuid', 'course_id', 'item_id')
 
     inlines = (AssessmentWorkflowStepInline,)
-
-
-admin.site.register(AssessmentWorkflow, AssessmentWorkflowAdmin)
-admin.site.register(TeamAssessmentWorkflow, TeamAssessmentWorkflowAdmin)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edx-ora2",
-  "version": "6.14.5",
+  "version": "6.16.0",
   "repository": "https://github.com/openedx/edx-ora2.git",
   "dependencies": {
     "@edx/frontend-build": "8.0.6",

--- a/settings/base.py
+++ b/settings/base.py
@@ -45,7 +45,6 @@ USE_I18N = True
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale.
-USE_L10N = True
 
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py{311, 312}-django{42}, js, quality
+envlist = py{311, 312}-django{42,52}, js, quality
 
 [testenv]
 deps =
     -rrequirements/test.txt
     django42: Django>=4.2,<5.0
+    django52: Django>=5.2,<5.3
 
 commands =
     pytest
@@ -13,7 +14,6 @@ commands =
 allowlist_externals = make
 deps =
     -rrequirements/test.txt
-    Django>=4.2,<5.0
 commands =
     make install-js
     make static
@@ -35,4 +35,3 @@ commands =
     python manage.py makemessages -l eo
     make check_translations_up_to_date
     make validate_translations
-

--- a/urls.py
+++ b/urls.py
@@ -1,7 +1,7 @@
 import workbench.urls
 
-from django.conf.urls import include
 from django.contrib import admin
+from django.urls import include, path
 from django.urls import re_path
 from django.views.i18n import JavaScriptCatalog
 
@@ -21,12 +21,12 @@ urlpatterns = [
     re_path(r'^/?', include(workbench.urls)),
 
     # edx-ora2 apps
-    re_path(r'^peer/evaluations/', include(openassessment.assessment.urls)),
+    path('peer/evaluations/', include(openassessment.assessment.urls)),
 
     # JavaScript i18n
-    re_path(r'^jsi18n/$', JavaScriptCatalog.as_view(), JS_INFO_DICT),
+    path('jsi18n/', JavaScriptCatalog.as_view(), JS_INFO_DICT),
 
     # File upload to local filesystem
-    re_path(r'^openassessment/storage',
+    path('openassessment/storage',
             include(openassessment.fileupload.urls)),
 ]


### PR DESCRIPTION
**TL;DR -**

Support upgrading to django 5.2 while maintaining django 4.2 compatibility.



Closes: https://github.com/openedx/edx-ora2/issues/2290

**What changed?**

* Ran django-upgrade and updated migration
* Added django52 target to tox & CI
* Added Django 5.2 to setup docs
* Fixed quality

**Developer Checklist**

- [x] Reviewed the [release process](https://github.com/openedx/edx-ora2/blob/master/.github/release_process.md)
- [x] Translations and JS/SASS compiled
- [x] Bumped version number in [openassessment/\_\_init\_\_.py](https://github.com/openedx/edx-ora2/blob/master/openassessment/__init__.py#L4) and [package.json](https://github.com/openedx/edx-ora2/blob/master/package.json#L3)

**Testing Instructions**

Code review + green CI should be sufficient to test this change.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality

FYI: @openedx/content-aurora
