### PR TITLE
Abstract-tech: Fix: preserve ORA date_config_type through OLX export/import

### DIFF
--- a/openassessment/__init__.py
+++ b/openassessment/__init__.py
@@ -2,4 +2,4 @@
 Initialization Information for Open Assessment Module
 """
 
-__version__ = '7.1.0'
+__version__ = '7.1.1'

--- a/openassessment/xblock/openassessmentblock.py
+++ b/openassessment/xblock/openassessmentblock.py
@@ -935,6 +935,7 @@ class OpenAssessmentBlock(
         block.allow_latex = config['allow_latex']
         block.allow_learner_resubmissions = config['allow_learner_resubmissions']
         block.allow_multiple_files = config['allow_multiple_files']
+        block.date_config_type = config['date_config_type'] or DATE_CONFIG_MANUAL
         block.display_name = config['title']
         block.file_upload_response = config['file_upload_response']
         block.file_upload_type = config['file_upload_type']

--- a/openassessment/xblock/test/test_xml.py
+++ b/openassessment/xblock/test/test_xml.py
@@ -151,6 +151,7 @@ class TestSerializeContent(TestCase):
         self.oa_block.teams_enabled = data.get('teams_enabled', None)
         self.oa_block.selected_teamset_id = data.get('selected_teamset_id', None)
         self.oa_block.show_rubric_during_response = data.get('show_rubric_during_response')
+        self.oa_block.date_config_type = data.get('date_config_type', None)
 
     @ddt.file_data('data/serialize.json')
     def test_serialize(self, data):
@@ -559,3 +560,117 @@ class TestParseFromXml(TestCase):
     def test_parse_from_xml_error(self, data):
         with self.assertRaises(UpdateFromXmlError):
             parse_from_xml_str("".join(data['xml']))
+
+
+class TestDateConfigTypeXml(TestCase):
+    """
+    Regression tests for round-tripping `date_config_type` through XML
+    (course export/import, re-run, and other OLX round-trip flows).
+    """
+    MINIMAL_XML = (
+        '<openassessment{attrs}>'
+        '<title>Foo</title>'
+        '<assessments>'
+        '<assessment name="peer-assessment" start="2014-02-27T09:46:28" due="2014-03-01T00:00:00" '
+        'must_grade="5" must_be_graded_by="3" />'
+        '<assessment name="self-assessment" start="2014-04-01T00:00:00" due="2014-06-01T00:00:00" />'
+        '<assessment name="staff-assessment" required="False" />'
+        '</assessments>'
+        '<rubric>'
+        '<prompt>Test prompt</prompt>'
+        '<criterion>'
+        '<name>Test criterion</name>'
+        '<label>Test criterion label</label>'
+        '<prompt>Test criterion prompt</prompt>'
+        '<option points="0"><name>No</name><label>No label</label><explanation>No explanation</explanation></option>'
+        '<option points="2"><name>Yes</name><label>Yes label</label><explanation>Yes explanation</explanation></option>'
+        '</criterion>'
+        '</rubric>'
+        '</openassessment>'
+    )
+
+    def _xml(self, date_config_type=None):
+        attrs = f' date_config_type="{date_config_type}"' if date_config_type is not None else ''
+        return self.MINIMAL_XML.format(attrs=attrs)
+
+    def test_parse_from_xml_reads_date_config_type(self):
+        config = parse_from_xml_str(self._xml('subsection'))
+        self.assertEqual(config['date_config_type'], 'subsection')
+
+    def test_parse_from_xml_missing_attribute_defaults_to_none(self):
+        # Backwards compatibility: XML exported before this fix (or that never
+        # set the field) has no "date_config_type" attribute at all. This must
+        # not error, and must not silently claim a value was set.
+        config = parse_from_xml_str(self._xml())
+        self.assertIsNone(config['date_config_type'])
+
+    def test_parse_from_xml_invalid_value_raises(self):
+        with self.assertRaises(UpdateFromXmlError):
+            parse_from_xml_str(self._xml('not_a_real_option'))
+
+    def test_serialize_writes_date_config_type(self):
+        oa_block = mock.MagicMock(OpenAssessmentBlock)
+        oa_block.title = 'Foo'
+        oa_block.display_name = 'Foo'
+        oa_block.prompts = create_prompts_list('Test prompt')
+        oa_block.prompts_type = 'text'
+        oa_block.rubric_criteria = TestSerializeContent.BASIC_CRITERIA
+        oa_block.rubric_assessments = TestSerializeContent.BASIC_ASSESSMENTS
+        oa_block.rubric_feedback_prompt = None
+        oa_block.rubric_feedback_default_text = None
+        oa_block.submission_start = None
+        oa_block.submission_due = None
+        oa_block.leaderboard_show = 0
+        oa_block.text_response = ''
+        oa_block.text_response_editor = 'text'
+        oa_block.file_upload_response = None
+        oa_block.file_upload_type = None
+        oa_block.white_listed_file_types = None
+        oa_block.allow_multiple_files = None
+        oa_block.allow_latex = None
+        oa_block.allow_learner_resubmissions = None
+        oa_block.resubmissions_grace_period = None
+        oa_block.group_access = {}
+        oa_block.teams_enabled = None
+        oa_block.selected_teamset_id = None
+        oa_block.show_rubric_during_response = None
+        oa_block.date_config_type = 'subsection'
+
+        xml = serialize_content(oa_block)
+        parsed = etree.fromstring(xml)
+        self.assertEqual(parsed.get('date_config_type'), 'subsection')
+
+    def test_round_trip_preserves_date_config_type(self):
+        config = parse_from_xml_str(self._xml('course_end'))
+        self.assertEqual(config['date_config_type'], 'course_end')
+
+        oa_block = mock.MagicMock(OpenAssessmentBlock)
+        oa_block.title = config['title']
+        oa_block.display_name = config['title']
+        oa_block.prompts = config['prompts']
+        oa_block.prompts_type = config['prompts_type']
+        oa_block.rubric_criteria = config['rubric_criteria']
+        oa_block.rubric_assessments = config['rubric_assessments']
+        oa_block.rubric_feedback_prompt = config['rubric_feedback_prompt']
+        oa_block.rubric_feedback_default_text = config['rubric_feedback_default_text']
+        oa_block.submission_start = config['submission_start']
+        oa_block.submission_due = config['submission_due']
+        oa_block.leaderboard_show = config['leaderboard_show']
+        oa_block.text_response = config['text_response']
+        oa_block.text_response_editor = config['text_response_editor']
+        oa_block.file_upload_response = config['file_upload_response']
+        oa_block.file_upload_type = config['file_upload_type']
+        oa_block.white_listed_file_types = config['white_listed_file_types']
+        oa_block.allow_multiple_files = config['allow_multiple_files']
+        oa_block.allow_latex = config['allow_latex']
+        oa_block.allow_learner_resubmissions = config['allow_learner_resubmissions']
+        oa_block.resubmissions_grace_period = config['resubmissions_grace_period']
+        oa_block.group_access = config['group_access']
+        oa_block.teams_enabled = config['teams_enabled']
+        oa_block.selected_teamset_id = config['selected_teamset_id']
+        oa_block.show_rubric_during_response = config['show_rubric_during_response']
+        oa_block.date_config_type = config['date_config_type']
+
+        reserialized_xml = serialize_content(oa_block)
+        reparsed_config = parse_from_xml_str(reserialized_xml)
+        self.assertEqual(reparsed_config['date_config_type'], 'course_end')

--- a/openassessment/xblock/utils/xml.py
+++ b/openassessment/xblock/utils/xml.py
@@ -13,6 +13,7 @@ import pytz
 
 from lxml import etree
 from openassessment.xblock.utils.data_conversion import update_assessments_format
+from openassessment.xblock.utils.defaults import DATE_CONFIG_MANUAL, DATE_CONFIG_SUBSECTION, DATE_CONFIG_COURSE_END
 from openassessment.xblock.lms_mixin import GroupAccessDict
 
 log = logging.getLogger(__name__)
@@ -725,6 +726,10 @@ def serialize_content_to_xml(oa_block, root):
     if oa_block.submission_due is not None:
         root.set('submission_due', str(oa_block.submission_due))
 
+    # Set date configuration type
+    if oa_block.date_config_type is not None:
+        root.set('date_config_type', str(oa_block.date_config_type))
+
     # Set leaderboard show
     if oa_block.leaderboard_show:
         root.set('leaderboard_show', str(oa_block.leaderboard_show))
@@ -947,6 +952,15 @@ def parse_from_xml(root, block=None):
     if 'show_rubric_during_response' in root.attrib:
         show_rubric_during_response = _parse_boolean(str(root.attrib['show_rubric_during_response']))
 
+    date_config_type = None
+    if 'date_config_type' in root.attrib:
+        date_config_type = str(root.attrib['date_config_type'])
+        valid_date_config_types = [DATE_CONFIG_MANUAL, DATE_CONFIG_SUBSECTION, DATE_CONFIG_COURSE_END]
+        if date_config_type not in valid_date_config_types:
+            raise UpdateFromXmlError(
+                'The "date_config_type" value must be one of: {}.'.format(", ".join(valid_date_config_types))
+            )
+
     # Retrieve the title
     title_el = root.find('title')
     title = block and block.display_name
@@ -1023,6 +1037,7 @@ def parse_from_xml(root, block=None):
         'show_rubric_during_response': show_rubric_during_response,
         'allow_learner_resubmissions': allow_learner_resubmissions,
         'resubmissions_grace_period': resubmissions_grace_period,
+        'date_config_type': date_config_type,
     }
 
 


### PR DESCRIPTION
**TL;DR -** Fixes `date_config_type` (ORA schedule mode: manual / match subsection/match course end) silently resetting to "manual" whenever a course is exported and re-imported.

Issue: [#2418](https://github.com/openedx/edx-ora2/issues/2418)

**What changed?**
- `openassessment/xblock/utils/xml.py` -- `parse_from_xml()` now reads the `date_config_type` attribute off the XML node (if present), validates it against the three known values (`manual` / `subsection` / `course_end`), and includes it in the returned config dict. Raises `UpdateFromXmlError` on an invalid value, same pattern as the other validated fields in this function.
- `openassessment/xblock/utils/xml.py` -- `serialize_content_to_xml()` now writes `date_config_type` onto the XML node when it's set, following the same `if <field> is not None:` pattern used for every other field here.
- `openassessment/xblock/openassessmentblock.py` -- `parse_xml()` now assigns `date_config_type` from the parsed config dict onto the block, falling back to `DATE_CONFIG_MANUAL` when the value is `None` (i.e. an old export from before this fix, or a course that never touched this setting). This fallback is intentional and important for backward compatibility: assigning `None` directly would mark the field as explicitly set to `None` in the XBlock field system instead of falling through to the class default, which would change behavior for every existing course that's never used this setting.
- Added `TestDateConfigTypeXml` to `openassessment/xblock/test/test_xml.py` -- covers reading a valid value, missing-attribute backward compatibility, invalid-value rejection, serialization, and a full parse -> serialize -> parse round trip.


**Testing Instructions**

Automated:

pytest openassessment/xblock/test/test_xml.py -v


182 passed, 0 failed (177 pre-existing + 5 new, all in `TestDateConfigTypeXml`).

Manual, to reproduce the original bug and confirm the fix:
1. Create a course, add an ORA to a unit.
2. Open the ORA's Schedule tab, select "Match deadlines to the subsection due date", save, publish.
3. Studio -> Tools -> Export Course, download the tarball.
4. Create a new, empty course. Studio -> Tools -> Import Course, upload the tarball from step 3.
5. Open the ORA in the new course, go to the Schedule tab.

Before this fix: reverts to "Configure deadlines manually" with placeholder dates (2001-01-01 / 2099-12-31).
After this fix: correctly shows "Match deadlines to the subsection due date" selected.

